### PR TITLE
Serialise backfill per user to prevent interleaved resets

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Data.Enums;
@@ -11,6 +12,18 @@ namespace Jellyfin.Plugin.AchievementBadges.Services;
 
 public class WatchHistoryBackfillService
 {
+    /// <summary>
+    /// One gate per user, so two overlapping invocations can never interleave
+    /// their <c>ResetBadgesForUser</c> and accumulation passes over the same
+    /// profile. Without this, a double click on the admin page's scan button
+    /// (or a per-user scan issued while a scan-all is in flight) resets the
+    /// profile twice and counts part of the history twice, producing inflated
+    /// counters and badges unlocked on thresholds that were never really met.
+    /// The second caller waits and then performs its own clean pass, which is
+    /// safe because a single isolated backfill is idempotent.
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, object> _userGates = new();
+
     private readonly ILibraryManager _libraryManager;
     private readonly IUserManager _userManager;
     private readonly IUserDataManager _userDataManager;
@@ -61,6 +74,16 @@ public class WatchHistoryBackfillService
     }
 
     private object RunBackfillForUser(Guid userGuid, string username)
+    {
+        // Serialise per user. See _userGates for why.
+        var gate = _userGates.GetOrAdd(userGuid, static _ => new object());
+        lock (gate)
+        {
+            return RunBackfillForUserCore(userGuid, username);
+        }
+    }
+
+    private object RunBackfillForUserCore(Guid userGuid, string username)
     {
         var userId = userGuid.ToString("D");
         var moviesWatched = 0;


### PR DESCRIPTION
Fixes #49.

## Problem

`RunBackfillForUser` calls `ResetBadgesForUser(userId)` and then accumulates the user's history back into the profile. Nothing prevents two invocations from running that sequence over the same profile at the same time, so the two passes interleave: part of the history is counted twice, and badges unlock on thresholds that were never really met.

This is reachable from the admin configuration page, where neither the per-user "Scan watch history" button nor "Scan for ALL users" is disabled while a scan is in flight. A double click is enough, and so is a per-user scan started while a scan-all is still running. The endpoints are also callable directly.

Observed on Jellyfin 10.11.11 with plugin 2.2.0.0:

```
20:28:52  Starting backfill for "badpixel"   +  Reset badges for user
20:28:53  Starting backfill for "badpixel"   +  Reset badges for user
20:28:58  Backfill done for "badpixel": 31 movies, 446 episodes, 7 series, 0 books, 2 libraries.
20:29:00  Backfill done for "badpixel": 31 movies, 446 episodes, 7 series, 0 books, 2 libraries.
```

The profile left behind by the doubled run carried noticeably higher values than a single deterministic run yields (`TotalItemsWatched` 597 against 483, `SeriesCompleted` 14 against 7, 73 badges against 66), and the badges that later disappeared were all threshold badges sitting just above their limits under the inflated numbers.

## Change

One gate per user id, held across the reset plus accumulate sequence. A second caller waits and then performs its own clean pass, which is safe because a single isolated backfill is idempotent: I ran it twice in a row on a live instance and the stored profile was byte-identical both times.

`ConcurrentDictionary<Guid, object>` rather than a single lock, so scans for different users still run in parallel and `BackfillAllUsers` keeps its current throughput.

## Notes

- Verified with `dotnet build -c Release`: 0 warnings, 0 errors.
- Existing test suite passes: 67 passed, 0 failed.
- No test added. Covering this would mean mocking `ILibraryManager`, `IUserManager`, `IUserDataManager` and the concrete `AchievementBadgeService`, which felt disproportionate for a lock. Happy to add one in whatever style you prefer if you would rather have it.
- Disabling the scan buttons while a scan is in flight would be useful defence in depth, but I left the UI alone since the endpoints are callable directly and the guard belongs on the server side.
