### PR TITLE
Keep what the watch-history rebuild cannot reconstruct on reset

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/BadgeBehaviorTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/BadgeBehaviorTests.cs
@@ -466,4 +466,57 @@ public class BadgeBehaviorTests : IDisposable
         Assert.True(firstContact.Unlocked);
         Assert.Null(firstContact.UnlockDeviceId);
     }
+
+    /// <summary>
+    /// Regression test for the data loss described in issue #48.
+    /// <para>
+    /// ResetBadgesForUser exists so the watch-history backfill can recompute
+    /// counters. Counters are therefore expected to go back to zero. Nothing
+    /// else in the profile comes from playback, so nothing else may be lost:
+    /// media that has since been deleted can never be counted again, which
+    /// means a rebuild would otherwise revoke badges the user really earned
+    /// and hand back a showcase they never chose.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ResetBadgesForUser_KeepsWhatWatchHistoryCannotRebuild()
+    {
+        _badges.RecordPlayback(UserId, isMovie: true, libraryName: "Movies");
+
+        var before = _badges.PeekProfile(UserId)!;
+        var earned = before.Badges.Where(b => b.Unlocked).Select(b => b.Id).ToList();
+        Assert.NotEmpty(earned);
+
+        before.EquippedBadgeIds.Clear();
+        before.EquippedBadgeIds.Add(earned[0]);
+        before.OwnedCosmetics.Add("title-curator");
+        before.FriendRequestsSent.Add("22222222-2222-2222-2222-222222222222");
+        before.PowerUpInventory["streak-freeze"] = 2;
+        before.PrestigeLevel = 3;
+        before.LifetimeScoreSpent = 450;
+        before.Preferences.Language = "pt-br";
+
+        _badges.ResetBadgesForUser(UserId);
+
+        var after = _badges.PeekProfile(UserId)!;
+
+        // The one thing the backfill does rebuild.
+        Assert.Equal(0, after.Counters.TotalItemsWatched);
+
+        // Everything it cannot.
+        Assert.Equal(new[] { earned[0] }, after.EquippedBadgeIds);
+        Assert.Contains("title-curator", after.OwnedCosmetics);
+        Assert.Contains("22222222-2222-2222-2222-222222222222", after.FriendRequestsSent);
+        Assert.Equal(2, after.PowerUpInventory["streak-freeze"]);
+        Assert.Equal(3, after.PrestigeLevel);
+        Assert.Equal(450, after.LifetimeScoreSpent);
+        Assert.Equal("pt-br", after.Preferences.Language);
+
+        foreach (var id in earned)
+        {
+            Assert.True(
+                after.Badges.Single(b => b.Id == id).Unlocked,
+                $"badge {id} was earned before the reset and must stay earned");
+        }
+    }
 }

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -1571,11 +1571,85 @@ public class AchievementBadgeService : IDisposable
         userId = NormalizeUserId(userId);
         lock (_lock)
         {
+            _userProfiles.TryGetValue(userId, out var previous);
+
             var profile = CreateProfile(userId);
+            if (previous is not null)
+            {
+                PreserveNonDerivedState(previous, profile);
+            }
+
             _userProfiles[userId] = profile;
             Save();
             _logger.LogInformation("Reset badges for user {UserId}", userId);
             return profile.Badges.Select(CloneBadge).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Carry over everything a watch-history rebuild cannot reconstruct.
+    /// <para>
+    /// The reset exists so the backfill can recompute counters from playback
+    /// history. Counters are therefore left to be rebuilt, which is the point.
+    /// Everything else in the profile was never derived from playback: the
+    /// social graph, the shop inventory, the deliberate showcase, the user's
+    /// settings. Dropping it turns a scan into silent data loss, and the loss
+    /// is unrecoverable because the source it would be rebuilt from does not
+    /// exist.
+    /// </para>
+    /// <para>
+    /// Unlocks are carried over too. An unlock is a historical event, and
+    /// media that has since been deleted from the library can never be
+    /// counted again, so a rebuild would revoke badges the user genuinely
+    /// earned. Admins who need to un-award a badge have <c>RevokeBadge</c>
+    /// and the audit cleanup tool, which are explicit about it.
+    /// </para>
+    /// </summary>
+    private static void PreserveNonDerivedState(UserAchievementProfile previous, UserAchievementProfile profile)
+    {
+        profile.Preferences = previous.Preferences;
+
+        // Deliberate presentation choices.
+        profile.EquippedBadgeIds = new List<string>(previous.EquippedBadgeIds);
+        profile.PinnedBadgeIds = new List<string>(previous.PinnedBadgeIds);
+        profile.EquippedTitleBadgeId = previous.EquippedTitleBadgeId;
+        profile.EquippedThemeId = previous.EquippedThemeId;
+        profile.EquippedBadgeFrameId = previous.EquippedBadgeFrameId;
+        profile.EquippedCustomTitleId = previous.EquippedCustomTitleId;
+        profile.EquippedAvatarId = previous.EquippedAvatarId;
+        profile.EquippedBackgroundId = previous.EquippedBackgroundId;
+        profile.EquippedProfileBorderId = previous.EquippedProfileBorderId;
+
+        // Purchases and prestige. Spending happened; it cannot be replayed.
+        profile.OwnedCosmetics = new List<string>(previous.OwnedCosmetics);
+        profile.BoughtBadgeIds = new List<string>(previous.BoughtBadgeIds);
+        profile.PowerUpInventory = new Dictionary<string, int>(previous.PowerUpInventory);
+        profile.LifetimeScoreSpent = previous.LifetimeScoreSpent;
+        profile.StreakFreezesBanked = previous.StreakFreezesBanked;
+        profile.PrestigeLevel = previous.PrestigeLevel;
+
+        // Social graph. Nothing here comes from playback.
+        profile.Friends = new List<string>(previous.Friends);
+        profile.FriendRequestsSent = new List<string>(previous.FriendRequestsSent);
+        profile.FriendRequestsReceived = new List<string>(previous.FriendRequestsReceived);
+        profile.CompareHistory = new List<CompareHistoryEntry>(previous.CompareHistory);
+
+        // Already-earned badges stay earned.
+        var earned = previous.Badges
+            .Where(b => b.Unlocked)
+            .ToDictionary(b => b.Id, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var badge in profile.Badges)
+        {
+            if (!earned.TryGetValue(badge.Id, out var before))
+            {
+                continue;
+            }
+
+            badge.Unlocked = true;
+            badge.UnlockedAt = before.UnlockedAt;
+            badge.UnlockDeviceId = before.UnlockDeviceId;
+            badge.EarnSource = before.EarnSource;
         }
     }
 


### PR DESCRIPTION
Fixes #48.

## Problem

`ResetBadgesForUser` replaces the whole profile with a fresh one so the backfill can recompute counters from playback history. Recomputing the counters is the point of the scan, and that part is fine. The collateral is not: the same call also drops everything else in the profile, none of which was ever derived from playback.

Measured on a live instance, before and after a single `POST /users/{id}/backfill`:

```
equipped before : binge-deity, three-am-club, hidden-late-night-sage, late-graveyard, actor-devotee-150
equipped after  : first-contact, night-owl, weekend-warrior, genre-curious, genre-hopper
```

The showcase was not merely cleared. `AutoEquipNewUnlocks` then refilled the five empty slots with whatever happened to unlock first during the rebuild, so a deliberate choice of five Mythic badges was replaced by an arbitrary set of Common ones. The user only noticed because the badges on display changed.

In the same run `OwnedCosmetics` lost `title-curator`, and seven badges were revoked:

```
actor-devotee-150     Actor Obsession      Mythic
binge-deity           Binge Deity          Mythic
late-graveyard        Graveyard Shift      Mythic
director-devotee-50   Director Devotee     Legendary
lib-specialist-500    Library Master       Legendary
five-hundred-hours    500 Hour Club        Epic
decade-90s            90s Nostalgic        Uncommon
```

Revocation is not a rounding error, it is structural. The rebuild counts items currently in the library with `IsPlayed = true`. Media watched and later deleted can never be counted again, so any long-horizon badge is only reachable by users who never remove anything. A media server is not an archive, and most people rotate content.

The user's preferences survived visually only because theirs happened to match the defaults (`Language: default`, theme `default`, corner `bottom-left`). They are reset the same way, just invisibly.

## Change

`PreserveNonDerivedState` carries across the reset the state a watch-history rebuild cannot reconstruct:

- `Preferences`
- the showcase and cosmetic slots: `EquippedBadgeIds`, `PinnedBadgeIds`, `EquippedTitleBadgeId`, and the `Equipped*` ids
- purchases and prestige: `OwnedCosmetics`, `BoughtBadgeIds`, `PowerUpInventory`, `LifetimeScoreSpent`, `StreakFreezesBanked`, `PrestigeLevel`
- the social graph: `Friends`, `FriendRequestsSent`, `FriendRequestsReceived`, `CompareHistory`
- the unlocked state of already-earned badges: `Unlocked`, `UnlockedAt`, `UnlockDeviceId`, `EarnSource`

Counters are deliberately left out, so the scan still does what it is for.

Carrying unlocks over also removes a second-order effect: the unlock loop is guarded by `if (!badge.Unlocked && current >= def.TargetValue)`, so a preserved badge is skipped rather than re-unlocked, which avoids re-firing toasts and webhooks for badges the user earned months ago.

Admins who need to un-award a badge still have `RevokeBadge` and the audit cleanup tool, both of which are explicit about doing so.

## Notes

- `dotnet build -c Release`: 0 warnings, 0 errors.
- Test suite: 68 passed, 0 failed (67 existing plus one added).
- The added test, `ResetBadgesForUser_KeepsWhatWatchHistoryCannotRebuild`, asserts that counters do go back to zero and that everything else survives. I verified it fails without the fix (1 failed, 67 passed) and passes with it, so it is a real regression guard rather than a restatement of the implementation.
