### PR TITLE
Surface failed loads instead of drawing them as empty or loading

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -2906,9 +2906,26 @@ font-size:0.88em;
             });
         });
 
-        var summaryPromise     = loadSummary(userId).catch(function () {});
-        var leaderboardPromise = loadLeaderboard().catch(function () {});
-        var serverStatsPromise = loadServerStats().catch(function () {});
+        // Isolating the ancillary loads is right, but discarding their errors
+        // is not: each one owns a placeholder, and an empty catch leaves that
+        // placeholder as the terminal state. The profile header in particular
+        // sat on "Loading profile..." indefinitely, indistinguishable from a
+        // slow request, while reloadAll's own error path already had the
+        // correct message and could never fire. Keep the isolation, report
+        // the failure.
+        var summaryPromise = loadSummary(userId).catch(function (err) {
+            profileSubtitle.textContent = tr('admin.msg.profile_failed', 'Could not load profile.');
+            setSummary({ Unlocked: 0, Total: 0, Percentage: 0, EquippedCount: 0 });
+            console.warn('[AchievementBadges] summary load failed', err);
+        });
+        var leaderboardPromise = loadLeaderboard().catch(function (err) {
+            leaderboardBox.textContent = tr('admin.msg.lb_failed', 'Failed to load leaderboard.');
+            console.warn('[AchievementBadges] leaderboard load failed', err);
+        });
+        var serverStatsPromise = loadServerStats().catch(function (err) {
+            serverStatsBox.textContent = tr('admin.msg.server_stats_failed', 'Failed to load server stats.');
+            console.warn('[AchievementBadges] server stats load failed', err);
+        });
 
         return Promise.all([badgesPromise, summaryPromise, leaderboardPromise, serverStatsPromise]);
     }

--- a/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
@@ -1207,7 +1207,13 @@
         if (!fBox || !rBox) return;
         fBox.innerHTML = '<div class="ab-fd-empty"><span class="material-icons">hourglass_empty</span><div>' + tr('common.loading', 'Loading...') + '</div></div>';
         fetch(buildUrl('Plugins/AchievementBadges/users/'+uid+'/friends'), { headers: authHeaders(), credentials: 'include' })
-            .then(function(r){ return r.ok ? r.json() : null; })
+            .then(function(r){
+                // A failed request must not become an empty friends list. The
+                // two are drawn identically, so users read a 401 as "my pending
+                // requests were deleted" and send them again.
+                if (!r.ok) throw new Error('friends request failed: ' + r.status);
+                return r.json();
+            })
             .then(function(data){
                 data = data || { Friends: [], Incoming: [], Outgoing: [] };
                 var friends = data.Friends || [];
@@ -1341,8 +1347,14 @@
                 [friends, incoming, outgoing].forEach(function(arr){
                     arr.forEach(function(f){ window.__abFriendIds[String(f.UserId||'').toLowerCase().replace(/-/g,'')] = true; });
                 });
-            }).catch(function(){
-                fBox.innerHTML = '<div class="ab-fd-empty"><span class="material-icons">error_outline</span><div>' + tr('friends.load_failed', 'Failed to load friends.') + '</div></div>';
+            }).catch(function(err){
+                // Both panes have to say so. Reporting only in the friends
+                // pane left the requests pane looking like an empty inbox,
+                // which is exactly the state users mistake for lost data.
+                var msg = '<div class="ab-fd-empty"><span class="material-icons">error_outline</span><div>' + tr('friends.load_failed', 'Failed to load friends.') + '</div></div>';
+                fBox.innerHTML = msg;
+                rBox.innerHTML = msg;
+                console.warn('[AchievementBadges] friends load failed', err);
             });
     }
 

--- a/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
@@ -1588,8 +1588,15 @@
             renderQuestCards(res && res.Weekly, 'abSaWeeklyQuest');
             renderRerollSlot('abSaDailyRerollSlot', 'daily', dRem);
             renderRerollSlot('abSaWeeklyRerollSlot', 'weekly', wRem);
-        }).catch(function () {
-            var d = el('abSaDailyQuest'); if (d) d.innerHTML = '<div class="ab-muted">' + tr('quests.load_failed', 'Failed to load quests.') + '</div>';
+        }).catch(function (err) {
+            // Both panels own a "Loading..." placeholder, so both have to be
+            // overwritten. Writing only into the daily one left the weekly
+            // panel saying "Loading..." forever, which reads as a slow request
+            // rather than a failed one.
+            var msg = '<div class="ab-muted">' + tr('quests.load_failed', 'Failed to load quests.') + '</div>';
+            var d = el('abSaDailyQuest'); if (d) d.innerHTML = msg;
+            var w = el('abSaWeeklyQuest'); if (w) w.innerHTML = msg;
+            console.warn('[AchievementBadges] quests load failed', err);
         });
     }
 


### PR DESCRIPTION
Fixes #47.

Three places turn a failed request into a state the user cannot tell apart from a successful one. All three were reproduced on Jellyfin 10.11.11 with plugin 2.2.0.0, and in every case the server was healthy at the moment the UI was stuck:

```
GET /Plugins/AchievementBadges/users/<uid>/summary   200   119 bytes   0.030s
GET /Plugins/AchievementBadges/users/<uid>/quests    200   133 bytes   0.026s
GET /Plugins/AchievementBadges/users/<uid>/friends   200               0.044s
```

## sidebar.js, friends drawer

`r.ok ? r.json() : null` followed by `data = data || { Friends: [], Incoming: [], Outgoing: [] }` renders a failed request as an empty social graph. Empty and failed are drawn identically, so the reported symptom was a user re-sending the same six friend requests about five times over several days, convinced they were being deleted. They had never been lost; the server had them the whole time.

Now the non-ok response rejects, which reaches the existing catch. That catch also only wrote into the friends pane, leaving the requests pane looking like an empty inbox, so it now covers both.

## standalone.js, quests tab

The catch writes only into `abSaDailyQuest`. `abSaWeeklyQuest` keeps its initial placeholder, which is why the reported symptom was:

```
Daily quests
Failed to load quests.

Weekly quests
Loading...
```

Both containers are now written on the failure path. Worth noting that an empty payload is not the trigger: `renderQuestCards` handles that correctly with "No quests available.", so an error state really does mean the request failed.

## index.html, reloadAll

```js
var summaryPromise     = loadSummary(userId).catch(function () {});
var leaderboardPromise = loadLeaderboard().catch(function () {});
var serverStatsPromise = loadServerStats().catch(function () {});
```

The comment above these lines explains that an earlier `Promise.all` let one ancillary rejection clear the whole badge grid, and that isolating them fixed it. The isolation is right and this PR keeps it. What it changes is the silence: each of these owns a placeholder, so an empty catch makes that placeholder the terminal state. `loadSummary` is the only thing that sets the profile subtitle, so a failure left `Loading profile...` on screen indefinitely while the badge grid rendered normally from its own promise, making the page look healthy.

`reloadAll` already had the right message for this (`admin.msg.profile_failed`, "Could not load profile.") but it could never fire, because the rejection was discarded upstream. Each catch now writes its own message, using translation keys that already exist, and logs the rejection.

## Why a retry is the other half

On the affected instance, clicking **Refresh** populates the profile immediately: same `reloadAll`, same endpoint, the only difference being that the ApiClient and its token are ready by then. So these failures are transient and specific to startup, and a single retry would turn all three into successes rather than into a message.

`fetchJson` in `standalone.js` already implements exactly that, with a token-ready wait and a one-shot 401 retry, and its own comment describes the failure mode. Reusing that helper in the admin page and in the friends drawer would close the underlying cause. I left it out of this PR to keep the change small and reviewable, and because you may prefer a different shape for it. Happy to follow up with it.

## Notes

- `dotnet build -c Release`: 0 warnings, 0 errors.
- Test suite: 67 passed, 0 failed.
- `node --check` passes on both modified scripts.
- No new translation keys. All five strings used already existed in the files.
- The `innerHTML` writes mirror the surrounding code and use static translated strings, so no new injection surface.
