### PR TITLE
Allow custom request headers on outbound webhooks

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/SecurityTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/SecurityTests.cs
@@ -164,4 +164,62 @@ public class SecurityTests
         var ok = SvgSanitizer.TryValidate(svg, out var error);
         Assert.False(ok, $"Expected external <use href> to be rejected. Error was: {error}");
     }
+
+    // ============================================================
+    // WebhookHeaderParser — admin-supplied outbound headers
+    // ============================================================
+
+    [Fact]
+    public void WebhookHeaders_ParsesOneNameValuePerLine()
+    {
+        var parsed = WebhookHeaderParser.Parse("Authorization: Bearer abc123\nX-Source: jellyfin");
+
+        Assert.Equal(2, parsed.Count);
+        Assert.Equal(("Authorization", "Bearer abc123"), parsed[0]);
+        Assert.Equal(("X-Source", "jellyfin"), parsed[1]);
+    }
+
+    [Fact]
+    public void WebhookHeaders_SplitOnFirstColonOnly()
+    {
+        // Values legitimately contain colons: bearer tokens, URLs, times.
+        var parsed = WebhookHeaderParser.Parse("X-Callback: https://example.org:8443/hook");
+
+        Assert.Single(parsed);
+        Assert.Equal(("X-Callback", "https://example.org:8443/hook"), parsed[0]);
+    }
+
+    [Fact]
+    public void WebhookHeaders_IgnoresBlanksCommentsAndMalformedLines()
+    {
+        var parsed = WebhookHeaderParser.Parse("\n  \n# a comment\nnot-a-header\n: novalue\nX-Ok: 1\n");
+
+        Assert.Single(parsed);
+        Assert.Equal(("X-Ok", "1"), parsed[0]);
+    }
+
+    [Fact]
+    public void WebhookHeaders_DropsReservedNames()
+    {
+        // Content-* would be silently refused by HttpRequestMessage.Headers,
+        // and the signature envelope must not be forgeable from this box.
+        var parsed = WebhookHeaderParser.Parse(
+            "Content-Type: text/plain\n" +
+            "content-length: 0\n" +
+            "X-AchievementBadges-Signature: sha256=deadbeef\n" +
+            "x-achievementbadges-timestamp: 1\n" +
+            "X-Kept: yes");
+
+        Assert.Single(parsed);
+        Assert.Equal(("X-Kept", "yes"), parsed[0]);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   \n  \n")]
+    public void WebhookHeaders_EmptyInputSendsNothingExtra(string? raw)
+    {
+        Assert.Empty(WebhookHeaderParser.Parse(raw));
+    }
 }

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -1639,6 +1639,7 @@ public class AchievementBadgesController : ControllerBase
         public string? WebhookUrl { get; set; }
         public bool WebhookEnabled { get; set; }
         public string? WebhookMessageTemplate { get; set; }
+        public string? WebhookHeaders { get; set; }
     }
 
     [HttpGet("admin/webhook")]
@@ -1651,7 +1652,8 @@ public class AchievementBadgesController : ControllerBase
         {
             WebhookUrl = c?.WebhookUrl,
             WebhookEnabled = c?.WebhookEnabled ?? false,
-            WebhookMessageTemplate = c?.WebhookMessageTemplate
+            WebhookMessageTemplate = c?.WebhookMessageTemplate,
+            WebhookHeaders = c?.WebhookHeaders
         });
     }
 
@@ -1675,6 +1677,10 @@ public class AchievementBadgesController : ControllerBase
         {
             config.WebhookMessageTemplate = request.WebhookMessageTemplate!;
         }
+
+        // Assigned unconditionally, unlike the template above: clearing the
+        // box has to be able to remove the headers again.
+        config.WebhookHeaders = request?.WebhookHeaders ?? string.Empty;
         plugin.UpdateConfiguration(config);
         return Ok(new { Success = true });
     }

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
@@ -82,6 +82,19 @@ public class PluginConfiguration : BasePluginConfiguration
     // (preserves legacy behaviour for users who haven't generated one yet).
     public string WebhookSigningSecret { get; set; } = string.Empty;
 
+    // Extra request headers for outbound webhook POSTs, one "Name: value" per
+    // line. Discord and Slack carry their secret in the URL, so they never
+    // needed this, but endpoints that authenticate with a header (n8n, Home
+    // Assistant, an internal gateway) reject every delivery with 401/403 and
+    // the only workaround is an unauthenticated endpoint with the secret
+    // smuggled into the path. Empty = send nothing extra, which is the
+    // existing behaviour.
+    //
+    // Safe to carry credentials here because the client is created with
+    // AllowAutoRedirect = false, so a hostile receiver cannot 302 us into
+    // replaying the header somewhere else.
+    public string WebhookHeaders { get; set; } = string.Empty;
+
     public bool EnableUnlockToasts { get; set; } = true;
 
     public bool EnableHomeWidget { get; set; } = false;

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WebhookHeaderParser.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WebhookHeaderParser.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// Parses the admin-configured extra header block for outbound webhook POSTs.
+/// Format is one <c>Name: value</c> per line, which is what every other tool
+/// that offers this uses, so admins can paste what they already have.
+/// </summary>
+public static class WebhookHeaderParser
+{
+    /// <summary>
+    /// Split on the first colon only, so values may contain colons (a bearer
+    /// token, a URL). Blank lines and <c>#</c> comments are ignored, and
+    /// reserved names are dropped rather than silently misapplied.
+    /// </summary>
+    public static List<(string Name, string Value)> Parse(string? raw)
+    {
+        var result = new List<(string, string)>();
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return result;
+        }
+
+        foreach (var line in raw.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed[0] == '#')
+            {
+                continue;
+            }
+
+            var sep = trimmed.IndexOf(':', StringComparison.Ordinal);
+            if (sep <= 0)
+            {
+                continue;
+            }
+
+            var name = trimmed[..sep].Trim();
+            var value = trimmed[(sep + 1)..].Trim();
+            if (name.Length == 0 || IsReserved(name))
+            {
+                continue;
+            }
+
+            result.Add((name, value));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Names that must not come from this box.
+    /// <para>
+    /// <c>Content-*</c> belongs to the body: <c>HttpRequestMessage.Headers</c>
+    /// silently refuses those, so accepting them here would look like it
+    /// worked and quietly do nothing.
+    /// </para>
+    /// <para>
+    /// <c>X-AchievementBadges-*</c> is the signature envelope, so a stray line
+    /// cannot forge a signed delivery or overwrite a real signature.
+    /// </para>
+    /// </summary>
+    public static bool IsReserved(string name)
+        => name.StartsWith("Content-", StringComparison.OrdinalIgnoreCase)
+            || name.StartsWith("X-AchievementBadges-", StringComparison.OrdinalIgnoreCase);
+}

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -1641,6 +1641,12 @@ font-size:0.88em;
                         <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.webhook.template">Message template:</span><br>
                             <input type="text" id="abWebhookTemplate" style="width:100%; padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
                         </label>
+                        <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.webhook.headers">Extra request headers:</span><br>
+                            <textarea id="abWebhookHeaders" rows="3" placeholder="Authorization: Bearer abc123&#10;X-Source: jellyfin" style="width:100%; padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px; font-family:monospace;"></textarea>
+                            <div class="fieldDescription" data-i18n="admin.webhook.headers_desc">
+                                One <code>Name: value</code> per line. Leave empty for Discord and Slack, which carry their secret in the URL. Needed for endpoints that authenticate with a header. Content-* and X-AchievementBadges-* are ignored.
+                            </div>
+                        </label>
                         <button is="emby-button" type="button" class="raised button-submit" id="abWebhookSaveBtn" data-i18n="admin.btn_save_webhook">Save webhook config</button>
                         <div id="abWebhookStatus" class="secondaryText"></div>
                     </div>
@@ -3275,6 +3281,7 @@ font-size:0.88em;
     var webhookEnabledEl = document.getElementById('abWebhookEnabled');
     var webhookUrlEl = document.getElementById('abWebhookUrl');
     var webhookTemplateEl = document.getElementById('abWebhookTemplate');
+    var webhookHeadersEl = document.getElementById('abWebhookHeaders');
     var webhookSaveBtn = document.getElementById('abWebhookSaveBtn');
     var webhookStatusEl = document.getElementById('abWebhookStatus');
 
@@ -3283,13 +3290,15 @@ font-size:0.88em;
             webhookEnabledEl.checked = !!c.WebhookEnabled;
             webhookUrlEl.value = c.WebhookUrl || '';
             webhookTemplateEl.value = c.WebhookMessageTemplate || '';
+            if (webhookHeadersEl) webhookHeadersEl.value = c.WebhookHeaders || '';
         });
     }
     webhookSaveBtn.addEventListener('click', function () {
         fetchJson('Plugins/AchievementBadges/admin/webhook', 'POST', {
             WebhookEnabled: webhookEnabledEl.checked,
             WebhookUrl: webhookUrlEl.value,
-            WebhookMessageTemplate: webhookTemplateEl.value
+            WebhookMessageTemplate: webhookTemplateEl.value,
+            WebhookHeaders: webhookHeadersEl ? webhookHeadersEl.value : ''
         }).then(function () { webhookStatusEl.textContent = tr('admin.msg.saved', 'Saved.'); })
          .catch(function (e) { webhookStatusEl.textContent = tr('admin.msg.save_failed', 'Save failed:') + ' ' + (e.message || e); });
     });

--- a/Jellyfin.Plugin.AchievementBadges/Services/WebhookNotifier.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WebhookNotifier.cs
@@ -71,6 +71,7 @@ public class WebhookNotifier
         }
 
         var signingSecret = config.WebhookSigningSecret ?? string.Empty;
+        var extraHeaders = WebhookHeaderParser.Parse(config.WebhookHeaders);
 
         _ = Task.Run(async () =>
         {
@@ -94,6 +95,11 @@ public class WebhookNotifier
                     var sig = ComputeSignature(signingSecret, timestamp, json);
                     req.Headers.TryAddWithoutValidation("X-AchievementBadges-Signature", "sha256=" + sig);
                     req.Headers.TryAddWithoutValidation("X-AchievementBadges-Timestamp", timestamp);
+                }
+
+                foreach (var (name, value) in extraHeaders)
+                {
+                    req.Headers.TryAddWithoutValidation(name, value);
                 }
 
                 using var res = await _http.SendAsync(req).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #44.

## Problem

`WebhookNotifier` posts with no way to add request headers. Discord and Slack never needed one, since their secret lives in the URL. Anything that authenticates with a header rejects every delivery, and the log only shows the status:

```
[AchievementBadges] Webhook POST returned 403
```

On my instance the receiver is n8n with Header Auth. The workarounds I tried and discarded before opening the issue:

- Credentials in the URL (`https://user:pass@host/hook`) return 401. `HttpClient` does not convert URI userinfo into an `Authorization` header, unlike curl.
- A local reverse proxy that injects the header is blocked by `WebhookUrlValidator`, which resolves the hostname and rejects private ranges. Correct behaviour, and it closes that route.

What I ended up with is an unauthenticated n8n endpoint with a long random path acting as the secret. It works, but it is strictly worse than a header, and it means one endpoint in an otherwise header-authenticated setup has to be special-cased.

## Change

A `WebhookHeaders` setting, one `Name: value` per line, which is the format every comparable tool uses so admins can paste what they already have. Parsing lives in a new `WebhookHeaderParser` helper next to `WebhookUrlValidator`, which keeps it a pure function and directly testable, matching how the other webhook helper is structured.

Two classes of name are dropped rather than passed through:

- `Content-*`, because `HttpRequestMessage.Headers` silently refuses content headers. Accepting them would look like it worked and quietly do nothing.
- `X-AchievementBadges-*`, so a line in an admin text box cannot forge or overwrite the HMAC signature envelope.

Values are split on the first colon only, so bearer tokens and URLs survive. Blank lines and `#` comments are ignored.

The extra headers are applied after the signature block, which combined with the reserved-name filter means they can add to a signed delivery but never alter one.

## On sending credentials

The shared `HttpClient` is already constructed with `AllowAutoRedirect = false`, with a comment explaining that `WebhookUrlValidator` only vets the initial URL. That happens to close the usual objection to this feature: a hostile receiver cannot 302 the plugin into replaying an `Authorization` header at a third party. The guard was already there for SSRF, and it covers this too.

The value is stored in plugin configuration in plain text, the same as `WebhookSigningSecret` today.

## Notes

- `dotnet build -c Release`: 0 warnings, 0 errors.
- Test suite: 74 passed, 0 failed (67 existing plus 7 added).
- The added tests sit in `SecurityTests.cs` alongside the `WebhookUrlValidator` ones, and cover first-colon splitting, comments and malformed lines, the reserved-name filter in both casings, and empty input producing no headers at all so existing installs send exactly what they send today.
- The config page gets a textarea with a description that points Discord and Slack users at leaving it empty.
- `WebhookHeaders` is assigned unconditionally on save, unlike `WebhookMessageTemplate`, so clearing the box actually removes the headers.
