### PR TITLE
Inject into compressed responses instead of skipping them

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/WebInjectionTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WebInjectionTests.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Regression tests for issue #46. The client scripts are injected by
+/// <see cref="SidebarInjectionMiddleware"/> at request time, because the
+/// on-disk patch cannot work on the official Docker image where
+/// /jellyfin/jellyfin-web is root-owned and the server runs unprivileged.
+/// <para>
+/// The middleware used to skip any response carrying a Content-Encoding.
+/// Every browser sends <c>Accept-Encoding: gzip</c>, so that was the only
+/// branch browsers ever took: the scripts reached curl and nothing else.
+/// </para>
+/// </summary>
+public class WebInjectionTests
+{
+    private const string Marker = "achievementbadges-bootstrap";
+    private const string Page = "<html><body><div>content</div></body></html>";
+
+    private static async Task<(byte[] Body, string Encoding)> RunAsync(string? contentEncoding)
+    {
+        var payload = Encoding.UTF8.GetBytes(Page);
+        if (!string.IsNullOrEmpty(contentEncoding))
+        {
+            payload = ResponseCompression.Compress(payload, contentEncoding);
+        }
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/web/index.html";
+
+        var sink = new MemoryStream();
+        context.Response.Body = sink;
+
+        var middleware = new SidebarInjectionMiddleware(
+            async ctx =>
+            {
+                ctx.Response.ContentType = "text/html; charset=utf-8";
+                if (!string.IsNullOrEmpty(contentEncoding))
+                {
+                    ctx.Response.Headers["Content-Encoding"] = contentEncoding;
+                }
+
+                await ctx.Response.Body.WriteAsync(payload);
+            },
+            NullLogger<SidebarInjectionMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        return (sink.ToArray(), contentEncoding ?? string.Empty);
+    }
+
+    private static string Decode(byte[] body, string contentEncoding)
+        => string.IsNullOrEmpty(contentEncoding)
+            ? Encoding.UTF8.GetString(body)
+            : Encoding.UTF8.GetString(ResponseCompression.Decompress(body, contentEncoding));
+
+    [Fact]
+    public async Task Injects_IntoPlainHtml()
+    {
+        var (body, enc) = await RunAsync(null);
+        Assert.Contains(Marker, Decode(body, enc), System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("gzip")]
+    [InlineData("br")]
+    public async Task Injects_IntoCompressedHtml(string contentEncoding)
+    {
+        var (body, enc) = await RunAsync(contentEncoding);
+
+        // Still decodable as the negotiated encoding, so the client is
+        // unaffected beyond receiving the scripts it should always have had.
+        var html = Decode(body, enc);
+        Assert.Contains(Marker, html, System.StringComparison.Ordinal);
+        Assert.Contains("<div>content</div>", html, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PassesThrough_UnsupportedEncoding()
+    {
+        // deflate is ambiguous in HTTP, so it is left alone rather than
+        // risking a corrupt body. The original bytes must survive intact.
+        var payload = Encoding.UTF8.GetBytes(Page);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/web/index.html";
+        var sink = new MemoryStream();
+        context.Response.Body = sink;
+
+        var middleware = new SidebarInjectionMiddleware(
+            async ctx =>
+            {
+                ctx.Response.ContentType = "text/html; charset=utf-8";
+                ctx.Response.Headers["Content-Encoding"] = "deflate";
+                await ctx.Response.Body.WriteAsync(payload);
+            },
+            NullLogger<SidebarInjectionMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(payload, sink.ToArray());
+    }
+
+    [Fact]
+    public async Task DoesNotDoubleInject()
+    {
+        var already = "<html><body><!-- " + Marker + " --></body></html>";
+        var payload = ResponseCompression.Compress(Encoding.UTF8.GetBytes(already), "gzip");
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/web/index.html";
+        var sink = new MemoryStream();
+        context.Response.Body = sink;
+
+        var middleware = new SidebarInjectionMiddleware(
+            async ctx =>
+            {
+                ctx.Response.ContentType = "text/html; charset=utf-8";
+                ctx.Response.Headers["Content-Encoding"] = "gzip";
+                await ctx.Response.Body.WriteAsync(payload);
+            },
+            NullLogger<SidebarInjectionMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        var html = Decode(sink.ToArray(), "gzip");
+        var first = html.IndexOf(Marker, System.StringComparison.Ordinal);
+        Assert.True(first >= 0);
+        Assert.Equal(first, html.LastIndexOf(Marker, System.StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("gzip", true)]
+    [InlineData("GZIP", true)]
+    [InlineData(" br ", true)]
+    [InlineData("deflate", false)]
+    [InlineData("gzip, br", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void CanRoundTrip_OnlyClaimsWhatItHandles(string? encoding, bool expected)
+    {
+        Assert.Equal(expected, ResponseCompression.CanRoundTrip(encoding));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/ResponseCompression.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/ResponseCompression.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// Round-trips a compressed HTTP response body so text can be rewritten and
+/// handed back in the encoding the client negotiated.
+/// <para>
+/// Only <c>gzip</c> and <c>br</c> are handled. <c>deflate</c> is deliberately
+/// left out: HTTP disagrees with itself about whether it means raw DEFLATE or
+/// zlib-wrapped, and guessing wrong produces a corrupt body rather than a
+/// clean failure. Callers treat an unsupported encoding as "pass through
+/// untouched", which is the pre-existing behaviour.
+/// </para>
+/// </summary>
+public static class ResponseCompression
+{
+    public const string Gzip = "gzip";
+    public const string Brotli = "br";
+
+    public static bool CanRoundTrip(string? contentEncoding)
+    {
+        var name = Normalize(contentEncoding);
+        return name is Gzip or Brotli;
+    }
+
+    /// <summary>
+    /// Normalises a Content-Encoding header to a single lowercase token.
+    /// Returns an empty string when the response is not encoded, and the
+    /// raw trimmed value when it is something we do not handle, so callers
+    /// can distinguish "plain" from "unsupported".
+    /// </summary>
+    public static string Normalize(string? contentEncoding)
+    {
+        if (string.IsNullOrWhiteSpace(contentEncoding))
+        {
+            return string.Empty;
+        }
+
+        // A comma-separated list would mean stacked encodings; we only claim
+        // to understand a single one, so anything else falls through as
+        // unsupported and gets passed along untouched.
+        return contentEncoding.Trim().ToLowerInvariant();
+    }
+
+    public static byte[] Decompress(byte[] payload, string contentEncoding)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        using var source = new MemoryStream(payload);
+        using var decoder = CreateDecoder(source, contentEncoding);
+        using var output = new MemoryStream();
+        decoder.CopyTo(output);
+        return output.ToArray();
+    }
+
+    public static byte[] Compress(byte[] payload, string contentEncoding)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        using var output = new MemoryStream();
+        using (var encoder = CreateEncoder(output, contentEncoding))
+        {
+            encoder.Write(payload, 0, payload.Length);
+        }
+
+        return output.ToArray();
+    }
+
+    private static Stream CreateDecoder(Stream source, string contentEncoding)
+        => Normalize(contentEncoding) switch
+        {
+            Gzip => new GZipStream(source, CompressionMode.Decompress),
+            Brotli => new BrotliStream(source, CompressionMode.Decompress),
+            _ => throw new NotSupportedException($"Unsupported content encoding '{contentEncoding}'.")
+        };
+
+    private static Stream CreateEncoder(Stream destination, string contentEncoding)
+        => Normalize(contentEncoding) switch
+        {
+            Gzip => new GZipStream(destination, CompressionLevel.Fastest, leaveOpen: true),
+            Brotli => new BrotliStream(destination, CompressionLevel.Fastest, leaveOpen: true),
+            _ => throw new NotSupportedException($"Unsupported content encoding '{contentEncoding}'.")
+        };
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/SidebarInjectionMiddleware.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/SidebarInjectionMiddleware.cs
@@ -67,16 +67,33 @@ public class SidebarInjectionMiddleware
             var contentType = context.Response.ContentType;
             var contentEncoding = context.Response.Headers["Content-Encoding"].ToString();
 
-            // Only rewrite uncompressed text/html. If the response is gzip/br,
-            // streaming through our buffer as plain UTF-8 would mangle bytes,
-            // so pass it through untouched.
+            // Rewrite text/html whether or not it arrived compressed. Treating
+            // compressed bytes as UTF-8 would mangle them, so a gzip/br body is
+            // decoded first and re-encoded afterwards in the same format, which
+            // leaves the client seeing exactly what it negotiated.
+            //
+            // This used to bail out on any Content-Encoding. Every browser
+            // sends Accept-Encoding: gzip, so that branch was the only one
+            // browsers ever took and the scripts were never delivered to them.
+            // The injection only appeared to work because curl without
+            // --compressed takes the other branch.
             var isHtml = contentType != null && contentType.Contains("text/html", StringComparison.OrdinalIgnoreCase);
-            var isCompressed = !string.IsNullOrEmpty(contentEncoding);
+            var encoding = ResponseCompression.Normalize(contentEncoding);
+            var isCompressed = encoding.Length > 0;
+            var canRewrite = isHtml && (!isCompressed || ResponseCompression.CanRoundTrip(encoding));
 
-            if (isHtml && !isCompressed)
+            if (canRewrite)
             {
-                using var reader = new StreamReader(buffer, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
-                var html = await reader.ReadToEndAsync();
+                string html;
+                if (isCompressed)
+                {
+                    html = Encoding.UTF8.GetString(ResponseCompression.Decompress(buffer.ToArray(), encoding));
+                }
+                else
+                {
+                    using var reader = new StreamReader(buffer, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
+                    html = await reader.ReadToEndAsync();
+                }
 
                 // v1.9.0: marker fast-path. The injection marker
                 // <!-- achievementbadges-bootstrap --> is always emitted
@@ -105,6 +122,13 @@ public class SidebarInjectionMiddleware
                         StringComparison.OrdinalIgnoreCase);
 
                     var bytes = Encoding.UTF8.GetBytes(html);
+                    if (isCompressed)
+                    {
+                        // Re-encode in the same format, so Content-Encoding
+                        // stays truthful and the client decodes as usual.
+                        bytes = ResponseCompression.Compress(bytes, encoding);
+                    }
+
                     // Clear Content-Length so the framework re-derives it from the new body.
                     // Setting it to bytes.Length first caused a race on some Kestrel paths.
                     context.Response.ContentLength = null;


### PR DESCRIPTION
Fixes #46.

## Problem

`SidebarInjectionMiddleware` skips any response that carries a `Content-Encoding`:

```csharp
// Only rewrite uncompressed text/html. If the response is gzip/br,
// streaming through our buffer as plain UTF-8 would mangle bytes,
// so pass it through untouched.
if (isHtml && !isCompressed)
```

The reasoning is right. The conclusion gives up one step too early, because every browser sends `Accept-Encoding: gzip`. That branch is the only one a browser ever takes, so no browser has ever received the client scripts. It looks healthy from a shell, which is what made it hard to spot:

```
$ curl -s .../web/index.html | grep -c achievementbadges-bootstrap
1
$ curl -s --compressed .../web/index.html | grep -c achievementbadges-bootstrap
0
```

Same server, same second, 433 bytes apart (72102 against 71669).

This is more than a cosmetic gap because the middleware is the only delivery path on the official Docker image. `WebInjectionService` patches `index.html` on disk, and there it cannot:

```
$ docker exec jellyfin ls -la /jellyfin/jellyfin-web/index.html
-rw-r--r-- 1 root root 5331 Jun  6 12:43 /jellyfin/jellyfin-web/index.html
$ docker exec jellyfin id
uid=1000 gid=1000 groups=1000,991
```

which is exactly what the log reports on every start:

```
[AchievementBadges] Can't write "/jellyfin/jellyfin-web/index.html": "Access to the path ... is denied"
[AchievementBadges] "Jellyfin's web directory is not writable..."
```

So on a stock container install, no browser gets the sidebar, the toasts, the item ribbon or the standalone page.

## Change

Decode `gzip` and `br` before rewriting, re-encode afterwards in the same format. `Content-Encoding` stays truthful and the client decodes exactly as it would have.

`deflate` is deliberately left alone and passed through untouched, as today. HTTP disagrees with itself about whether it means raw DEFLATE or zlib-wrapped, and guessing wrong yields a corrupt body rather than a clean failure. Unknown or stacked encodings (`gzip, br`) also pass through.

The codec round-trip lives in a small `ResponseCompression` helper next to the other helpers, which keeps it a pure function and testable on its own.

Everything else is unchanged: the 5 MB buffer cap, the path prefilter, the 4 KB tail fast-path that avoids double injection, and the `Content-Length = null` handling.

## Why not File Transformation

In the issue I suggested registering with the File Transformation plugin, since it runs before compression. Having read the code I no longer think that is the right first move here:

- `FileTransformationIntegration.TryInject()` is currently a stub that logs `No injection rules configured` and returns, so the log line some users see is expected rather than a symptom.
- Going that route would make a third-party plugin a hard requirement for the UI to appear at all.

Fixing the middleware keeps the plugin self-contained and helps every install immediately. File Transformation remains a reasonable additional path later, and this change does not stand in its way.

## Notes

- `dotnet build -c Release`: 0 warnings, 0 errors.
- Test suite: 79 passed, 0 failed (67 existing plus 12 added).
- The added `WebInjectionTests` drive the real middleware through a `DefaultHttpContext` rather than testing the helper in isolation, so they exercise the actual delivery path.
- I verified they fail without the fix: `Injects_IntoCompressedHtml(gzip)` and `Injects_IntoCompressedHtml(br)` both fail, 2 failed and 77 passed. The plain-HTML, pass-through and no-double-injection tests pass either way on purpose, since they guard the behaviour this change must not break.
