### PR TITLE
Announce milestone cosmetics instead of granting them in silence

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/MilestoneCosmeticTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/MilestoneCosmeticTests.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Regression tests for issue #55. Milestone cosmetics used to be granted with
+/// no signal of any kind, so the only way to discover a title earned over
+/// months of play was to notice it later sitting in the inventory.
+/// <para>
+/// <c>CheckMilestones</c> now reports what it granted on each call, which is
+/// what lets the caller announce it. These tests pin the two properties that
+/// make that safe to act on: it reports only what is new, and it reports
+/// nothing on a repeat call.
+/// </para>
+/// </summary>
+public class MilestoneCosmeticTests
+{
+    private static ShopService NewShop()
+        => new(new PowerUpService(NullLogger<PowerUpService>.Instance), NullLogger<ShopService>.Instance);
+
+    private static UserAchievementProfile NewProfile()
+        => new() { UserId = "11111111-1111-1111-1111-111111111111" };
+
+    [Fact]
+    public void ReportsOnlyWhatItGranted()
+    {
+        var shop = NewShop();
+        var profile = NewProfile();
+
+        var granted = shop.CheckMilestones(profile, 2600);
+
+        var ids = granted.Select(c => c.Id).ToList();
+        Assert.Contains("title-cinephile", ids);   // 1000
+        Assert.Contains("title-marathoner", ids);  // 2500
+        Assert.DoesNotContain("title-curator", ids); // 5000, not reached
+
+        // Everything reported must actually be owned now.
+        Assert.All(granted, c => Assert.Contains(c.Id, profile.OwnedCosmetics));
+    }
+
+    [Fact]
+    public void ReportsNothingOnRepeatCall()
+    {
+        var shop = NewShop();
+        var profile = NewProfile();
+
+        var first = shop.CheckMilestones(profile, 5000);
+        Assert.NotEmpty(first);
+
+        var second = shop.CheckMilestones(profile, 5000);
+
+        // Without this, every rebuild would announce the same titles again.
+        // The user-visible symptom on the instance that prompted the issue was
+        // 21 grant log lines for 4 distinct titles.
+        Assert.Empty(second);
+    }
+
+    [Fact]
+    public void ReportsNothingBelowTheFirstThreshold()
+    {
+        var shop = NewShop();
+        var profile = NewProfile();
+
+        Assert.Empty(shop.CheckMilestones(profile, 999));
+    }
+
+    [Fact]
+    public void GrantedCosmeticsCarryWhatAnAnnouncementNeeds()
+    {
+        var shop = NewShop();
+        var profile = NewProfile();
+
+        var cosmetic = shop.CheckMilestones(profile, 1000).Single(c => c.Id == "title-cinephile");
+
+        Assert.False(string.IsNullOrWhiteSpace(cosmetic.DisplayName));
+        Assert.NotNull(cosmetic.MilestoneScore);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -2108,7 +2108,23 @@ public class AchievementBadgeService : IDisposable
             // v2.0 - Score-milestone cosmetic auto-unlocks (Cinephile at
             // 1000, Marathoner at 2500, Curator at 5000). Idempotent;
             // already-owned cosmetics are skipped.
-            _shop?.CheckMilestones(profile, profile.ScoreBank);
+            var grantedCosmetics = _shop?.CheckMilestones(profile, profile.ScoreBank);
+
+            // Tell the user. These are gated behind months of play and used to
+            // arrive with no signal at all, so the only way to discover one was
+            // to notice it later in the inventory. Gated on !Silent for the
+            // same reason badge unlocks are: a backfill re-grants every
+            // milestone the user has ever crossed, and announcing those would
+            // mean a burst of messages per rebuild.
+            if (grantedCosmetics is { Count: > 0 } && !context.Silent)
+            {
+                var cosmeticUserName = ResolveUserName(userId);
+                foreach (var cosmetic in grantedCosmetics)
+                {
+                    _webhookNotifier?.NotifyCosmeticUnlock(cosmeticUserName, cosmetic, profile.ScoreBank);
+                    _auditLog?.Log(userId, cosmeticUserName, "cosmetic-unlock", cosmetic.DisplayName);
+                }
+            }
 
             // For historical backfills, use the original played date as the unlock stamp so the
             // toast poller's "UnlockedAt > LAST_SEEN" check won't match (stops scan-spam toasts).

--- a/Jellyfin.Plugin.AchievementBadges/Services/ShopService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/ShopService.cs
@@ -539,10 +539,17 @@ public class ShopService
     /// Run the score-milestone check whenever a user gains score. Any
     /// cosmetics whose MilestoneScore the user has now crossed get added
     /// to OwnedCosmetics. Idempotent (already-owned cosmetics are skipped).
+    /// <para>
+    /// Returns what was granted on this call, so the caller can tell the user
+    /// about it. Premium titles are gated behind months of play, and until
+    /// v2.2 they arrived with no toast, webhook or feed entry: the only trace
+    /// was the log line below, which no user reads.
+    /// </para>
     /// </summary>
-    public void CheckMilestones(UserAchievementProfile profile, int currentScore)
+    public List<CosmeticItem> CheckMilestones(UserAchievementProfile profile, int currentScore)
     {
-        if (profile is null) return;
+        var granted = new List<CosmeticItem>();
+        if (profile is null) return granted;
         EnsureDefaultsOwned(profile);
         foreach (var c in _cosmeticItems)
         {
@@ -551,11 +558,14 @@ public class ShopService
             if (!profile.OwnedCosmetics.Contains(c.Id))
             {
                 profile.OwnedCosmetics.Add(c.Id);
+                granted.Add(c);
                 _logger.LogInformation(
                     "[AchievementBadges] Auto-unlocked milestone cosmetic {Id} for user {UserId} at score {Score}.",
                     c.Id, profile.UserId, currentScore);
             }
         }
+
+        return granted;
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.AchievementBadges/Services/WebhookNotifier.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WebhookNotifier.cs
@@ -27,7 +27,37 @@ public class WebhookNotifier
         _logger = logger;
     }
 
+    /// <summary>
+    /// Milestone cosmetics are earned the same way badges are, from the user's
+    /// point of view, so they go out through the same template and the same
+    /// endpoint. Rarity has no meaning for a cosmetic, so the milestone score
+    /// that unlocked it takes that slot, which is the interesting number.
+    /// </summary>
+    public void NotifyCosmeticUnlock(string userName, CosmeticItem cosmetic, int milestoneScore)
+    {
+        if (cosmetic is null)
+        {
+            return;
+        }
+
+        Notify(
+            userName,
+            cosmetic.DisplayName,
+            milestoneScore.ToString(System.Globalization.CultureInfo.InvariantCulture) + " score",
+            cosmetic.Description);
+    }
+
     public void NotifyUnlock(string userName, AchievementBadge badge)
+    {
+        if (badge is null)
+        {
+            return;
+        }
+
+        Notify(userName, badge.Title, badge.Rarity, badge.Description);
+    }
+
+    private void Notify(string userName, string title, string rarity, string description)
     {
         var config = Plugin.Instance?.Configuration;
         if (config is null || !config.WebhookEnabled || string.IsNullOrWhiteSpace(config.WebhookUrl))
@@ -48,9 +78,9 @@ public class WebhookNotifier
             : config.WebhookMessageTemplate!;
 
         var safeUser = Sanitize(userName);
-        var safeTitle = Sanitize(badge.Title);
-        var safeRarity = Sanitize(badge.Rarity);
-        var safeDescription = Sanitize(badge.Description);
+        var safeTitle = Sanitize(title);
+        var safeRarity = Sanitize(rarity);
+        var safeDescription = Sanitize(description);
 
         var content = template
             .Replace("{user}", string.IsNullOrEmpty(safeUser) ? "Someone" : safeUser, StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Fixes #55.

## Problem

`ShopService.CheckMilestones` grants the cosmetic, writes a log line, and returns `void`. That is the entire notification path. `WebhookNotifier.NotifyUnlock` only accepts an `AchievementBadge`, and the client toast poller reads `users/{id}/unlocks-since`, which returns badges, so a cosmetic cannot reach either.

The result is that the reward with the longest lead time is the one that arrives without a word. From the catalog comment:

```
// cheap cosmetics are 1-2 weeks of play, premium milestone titles are months
```

On the instance that prompted the issue, the user had four titles and had never seen any of them arrive.

## Change

`CheckMilestones` returns the cosmetics it granted on that call. The call site in `AchievementBadgeService` announces them, since it already holds the `WebhookNotifier`, the audit log and the resolved user name.

Deliberately not injecting the notifier into `ShopService`: the badge service already depends on the shop, so that direction would be circular.

`WebhookNotifier` gains `NotifyCosmeticUnlock`. The send path is now shared with `NotifyUnlock` through a private `Notify(userName, title, rarity, description)`, so cosmetics reuse the admin's existing message template and endpoint rather than introducing a second format to configure. Rarity has no meaning for a cosmetic, so the milestone score takes that slot, which is the interesting number anyway:

```
{user} unlocked {badge} ({rarity}) — {description}
badpixel unlocked Curator (5000 score) — <cosmetic description>
```

## Gated on !Silent

This is the part I would look at hardest in review. A backfill re-grants every milestone the user has ever crossed, so announcing those would mean a burst per rebuild. The instance in the issue logged 21 grants for 4 distinct titles, all during rebuilds, none during live playback.

Badge unlocks already use exactly this guard at the same call site, so cosmetics now follow the rule that was already there rather than inventing one.

The two admin call sites in the controller keep discarding the return value. They are recompute tools, and firing notifications from an admin action seemed like the wrong default. Easy to change if you disagree.

## Notes

- `dotnet build -c Release`: 0 warnings, 0 errors.
- Test suite: 71 passed, 0 failed (67 existing plus 4 added).
- The added tests pin the two properties that make the return value safe to act on: it reports only what is newly granted, and it reports nothing on a repeat call. The second one is what stops the rebuild burst from becoming a notification burst.
- A client-side toast is the natural follow-up but needs an `unlocks-since` equivalent for cosmetics, so I left it out of this PR.
