### PR TITLE
Floor rebuilt counters and keep dated snapshots so a scan never loses progress

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/BadgeBehaviorTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/BadgeBehaviorTests.cs
@@ -466,4 +466,57 @@ public class BadgeBehaviorTests : IDisposable
         Assert.True(firstContact.Unlocked);
         Assert.Null(firstContact.UnlockDeviceId);
     }
+
+    /// <summary>
+    /// Regression test for the data loss described in issue #48.
+    /// <para>
+    /// ResetBadgesForUser exists so the watch-history backfill can recompute
+    /// counters. Counters are therefore expected to go back to zero. Nothing
+    /// else in the profile comes from playback, so nothing else may be lost:
+    /// media that has since been deleted can never be counted again, which
+    /// means a rebuild would otherwise revoke badges the user really earned
+    /// and hand back a showcase they never chose.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void ResetBadgesForUser_KeepsWhatWatchHistoryCannotRebuild()
+    {
+        _badges.RecordPlayback(UserId, isMovie: true, libraryName: "Movies");
+
+        var before = _badges.PeekProfile(UserId)!;
+        var earned = before.Badges.Where(b => b.Unlocked).Select(b => b.Id).ToList();
+        Assert.NotEmpty(earned);
+
+        before.EquippedBadgeIds.Clear();
+        before.EquippedBadgeIds.Add(earned[0]);
+        before.OwnedCosmetics.Add("title-curator");
+        before.FriendRequestsSent.Add("22222222-2222-2222-2222-222222222222");
+        before.PowerUpInventory["streak-freeze"] = 2;
+        before.PrestigeLevel = 3;
+        before.LifetimeScoreSpent = 450;
+        before.Preferences.Language = "pt-br";
+
+        _badges.ResetBadgesForUser(UserId);
+
+        var after = _badges.PeekProfile(UserId)!;
+
+        // The one thing the backfill does rebuild.
+        Assert.Equal(0, after.Counters.TotalItemsWatched);
+
+        // Everything it cannot.
+        Assert.Equal(new[] { earned[0] }, after.EquippedBadgeIds);
+        Assert.Contains("title-curator", after.OwnedCosmetics);
+        Assert.Contains("22222222-2222-2222-2222-222222222222", after.FriendRequestsSent);
+        Assert.Equal(2, after.PowerUpInventory["streak-freeze"]);
+        Assert.Equal(3, after.PrestigeLevel);
+        Assert.Equal(450, after.LifetimeScoreSpent);
+        Assert.Equal("pt-br", after.Preferences.Language);
+
+        foreach (var id in earned)
+        {
+            Assert.True(
+                after.Badges.Single(b => b.Id == id).Unlocked,
+                $"badge {id} was earned before the reset and must stay earned");
+        }
+    }
 }

--- a/Jellyfin.Plugin.AchievementBadges.Tests/DataResilienceTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/DataResilienceTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using Jellyfin.Plugin.AchievementBadges.Configuration;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Data resilience tests, the completion of issue #48. PR #51 made the
+/// scan keep everything a rebuild cannot reconstruct; these pin the two
+/// remaining loss windows closed:
+/// <list type="bullet">
+/// <item>counter monotonicity: a watch history rebuild floors every lifetime
+/// counter at its pre scan value, so media deleted since it was watched can
+/// never shrink totals;</item>
+/// <item>daily snapshots: the service keeps dated copies of badges.json under
+/// {pluginData}/backups with retention pruning, so an accidental scan or a
+/// corrupted write can be rolled back days later, not only minutes.</item>
+/// </list>
+/// </summary>
+public class DataResilienceTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly AchievementBadgeService _badges;
+
+    public DataResilienceTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "abfork_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var paths = new Mock<IApplicationPaths>();
+        paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        var userManager = new Mock<IUserManager>().Object;
+        var webhook = new WebhookNotifier(NullLogger<WebhookNotifier>.Instance);
+        var audit = new AuditLogService(paths.Object, NullLogger<AuditLogService>.Instance);
+
+        _badges = new AchievementBadgeService(
+            paths.Object, userManager, webhook, audit,
+            NullLogger<AchievementBadgeService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private const string UserId = "22222222-2222-2222-2222-222222222222";
+
+    [Fact]
+    public void CounterFloor_NumericTotals_NeverGoBackwards()
+    {
+        var previous = new UserAchievementCounters
+        {
+            MoviesWatched = 33,
+            TotalItemsWatched = 598,
+            TotalMinutesWatched = 31008,
+            BestWatchStreak = 9,
+            LongestItemMinutes = 240
+        };
+        var rebuilt = new UserAchievementCounters
+        {
+            MoviesWatched = 5,
+            TotalItemsWatched = 40,
+            TotalMinutesWatched = 900,
+            BestWatchStreak = 12,
+            LongestItemMinutes = 100
+        };
+
+        CounterFloor.Apply(previous, rebuilt);
+
+        Assert.Equal(33, rebuilt.MoviesWatched);
+        Assert.Equal(598, rebuilt.TotalItemsWatched);
+        Assert.Equal(31008, rebuilt.TotalMinutesWatched);
+        Assert.Equal(240, rebuilt.LongestItemMinutes);
+        // A rebuild that found MORE keeps its own larger value.
+        Assert.Equal(12, rebuilt.BestWatchStreak);
+    }
+
+    [Fact]
+    public void CounterFloor_FlagsSetsDictsAndDates_MergeMonotonically()
+    {
+        var previous = new UserAchievementCounters
+        {
+            WatchedOnChristmas = true,
+            LastWatchDate = new DateOnly(2026, 7, 30)
+        };
+        previous.GenresWatched.Add("Drama");
+        previous.GenresWatched.Add("Horror");
+        previous.DecadesWatched.Add(1980);
+        previous.GenreItemCounts["Drama"] = 25;
+        previous.GenreItemCounts["Horror"] = 4;
+        previous.MusicGenreListeningSeconds["Jazz"] = 7200;
+
+        var rebuilt = new UserAchievementCounters
+        {
+            WatchedOnChristmas = false,
+            LastWatchDate = new DateOnly(2026, 6, 1)
+        };
+        rebuilt.GenresWatched.Add("Drama");
+        rebuilt.GenresWatched.Add("Comedy");
+        rebuilt.GenreItemCounts["Drama"] = 3;
+        rebuilt.GenreItemCounts["Comedy"] = 8;
+
+        CounterFloor.Apply(previous, rebuilt);
+
+        Assert.True(rebuilt.WatchedOnChristmas);
+        Assert.Equal(new DateOnly(2026, 7, 30), rebuilt.LastWatchDate);
+        Assert.Superset(new[] { "Drama", "Horror", "Comedy" }.ToHashSet(), rebuilt.GenresWatched);
+        Assert.Contains(1980, rebuilt.DecadesWatched);
+        Assert.Equal(25, rebuilt.GenreItemCounts["Drama"]);
+        Assert.Equal(4, rebuilt.GenreItemCounts["Horror"]);
+        Assert.Equal(8, rebuilt.GenreItemCounts["Comedy"]);
+        Assert.Equal(7200, rebuilt.MusicGenreListeningSeconds["Jazz"]);
+    }
+
+    [Fact]
+    public void Service_SnapshotAndFloor_RoundTripThroughProfile()
+    {
+        Assert.Null(_badges.SnapshotCountersForUser(UserId));
+
+        // Create the profile with one genuine playback.
+        _badges.RecordPlayback(new PlaybackContext
+        {
+            UserId = UserId,
+            ItemId = Guid.NewGuid().ToString("D"),
+            IsMovie = true,
+            Silent = true
+        });
+
+        var snapshot = _badges.SnapshotCountersForUser(UserId);
+        Assert.NotNull(snapshot);
+
+        // Simulate the state a scan against a shrunken library would leave by
+        // flooring with a snapshot that is far ahead of the live counters.
+        snapshot!.MoviesWatched = 33;
+        snapshot.TotalMinutesWatched = 31008;
+        _badges.ApplyCounterFloor(UserId, snapshot);
+
+        var counters = _badges.PeekProfile(UserId)!.Counters;
+        Assert.Equal(33, counters.MoviesWatched);
+        Assert.Equal(31008, counters.TotalMinutesWatched);
+
+        // Null snapshot (fresh user before the scan) is a clean no op.
+        _badges.ApplyCounterFloor(UserId, null);
+        Assert.Equal(33, _badges.PeekProfile(UserId)!.Counters.MoviesWatched);
+    }
+
+    [Fact]
+    public void DailySnapshot_WritesOncePerDay_AndPrunesByFileNameDate()
+    {
+        var dataFile = Path.Combine(_dataDir, "snapshot-test", "badges.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(dataFile)!);
+        File.WriteAllText(dataFile, "{\"state\":\"day one\"}");
+
+        var backups = Path.Combine(Path.GetDirectoryName(dataFile)!, "backups");
+        var today = new DateOnly(2026, 8, 1);
+
+        AchievementBadgeService.WriteDailySnapshotCore(dataFile, today, 14);
+        var snapshotPath = Path.Combine(backups, "badges-2026-08-01.json");
+        Assert.Equal("{\"state\":\"day one\"}", File.ReadAllText(snapshotPath));
+
+        // Second save the same day must not overwrite the day's snapshot.
+        File.WriteAllText(dataFile, "{\"state\":\"day one, later\"}");
+        AchievementBadgeService.WriteDailySnapshotCore(dataFile, today, 14);
+        Assert.Equal("{\"state\":\"day one\"}", File.ReadAllText(snapshotPath));
+
+        // Pruning: a snapshot older than the window dies, a recent one and a
+        // foreign file survive.
+        File.WriteAllText(Path.Combine(backups, "badges-2026-07-01.json"), "{}");
+        File.WriteAllText(Path.Combine(backups, "badges-2026-07-25.json"), "{}");
+        File.WriteAllText(Path.Combine(backups, "not-a-snapshot.json"), "{}");
+        AchievementBadgeService.WriteDailySnapshotCore(dataFile, new DateOnly(2026, 8, 2), 14);
+
+        Assert.False(File.Exists(Path.Combine(backups, "badges-2026-07-01.json")));
+        Assert.True(File.Exists(Path.Combine(backups, "badges-2026-07-25.json")));
+        Assert.True(File.Exists(Path.Combine(backups, "not-a-snapshot.json")));
+        Assert.True(File.Exists(Path.Combine(backups, "badges-2026-08-02.json")));
+    }
+
+    [Fact]
+    public void DailySnapshot_RetentionZero_Disables()
+    {
+        var dataFile = Path.Combine(_dataDir, "disabled-test", "badges.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(dataFile)!);
+        File.WriteAllText(dataFile, "{}");
+
+        AchievementBadgeService.WriteDailySnapshotCore(dataFile, new DateOnly(2026, 8, 1), 0);
+
+        Assert.False(Directory.Exists(Path.Combine(Path.GetDirectoryName(dataFile)!, "backups")));
+    }
+
+    [Fact]
+    public void SnapshotRetention_DefaultsToFourteenDays()
+    {
+        Assert.Equal(14, new PluginConfiguration().SnapshotRetentionDays);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
@@ -65,6 +65,12 @@ public class PluginConfiguration : BasePluginConfiguration
     /// proper day-bucketing for retroactive credit.</summary>
     public bool BackfillSkipTimeWindowedBadges { get; set; } = true;
 
+    /// <summary>How many days of daily badges.json snapshots to keep
+    /// under {pluginData}/backups. A snapshot is written at most once per UTC
+    /// day, on the first save of the day, and pruned by the date in the file
+    /// name. Zero disables snapshots. Default 14.</summary>
+    public int SnapshotRetentionDays { get; set; } = 14;
+
     public string? WebhookUrl { get; set; }
 
     public bool WebhookEnabled { get; set; }

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/CounterFloor.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/CounterFloor.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Jellyfin.Plugin.AchievementBadges.Models;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// Merges a pre scan snapshot of <see cref="UserAchievementCounters"/> into the
+/// counters a watch history rebuild just produced, so a scan can only ever move
+/// counters forward (companion to issue #48).
+/// <para>
+/// A rebuild replays what the library holds today. Media deleted since it was
+/// watched is invisible to that replay, so every lifetime total it once fed
+/// would silently shrink. Unlocked badges already survive a reset (PR #51);
+/// this keeps the counters honest too: numeric totals and high water marks take
+/// the larger value, sticky holiday flags stay set, distinct value sets union,
+/// per key tallies keep the larger count per key, and dates keep the later day.
+/// Fields the replay can fully reconstruct simply keep the replayed value,
+/// because the snapshot holds nothing bigger.
+/// </para>
+/// </summary>
+public static class CounterFloor
+{
+    /// <summary>
+    /// Applies <paramref name="previous"/> as a floor onto
+    /// <paramref name="rebuilt"/>, mutating <paramref name="rebuilt"/> in
+    /// place. Reflection based on purpose: counters added by future upstream
+    /// versions are covered automatically instead of silently escaping the
+    /// floor. Computed properties have no setter and are skipped.
+    /// </summary>
+    public static void Apply(UserAchievementCounters previous, UserAchievementCounters rebuilt)
+    {
+        ArgumentNullException.ThrowIfNull(previous);
+        ArgumentNullException.ThrowIfNull(rebuilt);
+
+        foreach (var property in typeof(UserAchievementCounters).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanRead)
+            {
+                continue;
+            }
+
+            if (property.PropertyType == typeof(int) && property.CanWrite)
+            {
+                var prev = (int)property.GetValue(previous)!;
+                var curr = (int)property.GetValue(rebuilt)!;
+                if (prev > curr)
+                {
+                    property.SetValue(rebuilt, prev);
+                }
+            }
+            else if (property.PropertyType == typeof(long) && property.CanWrite)
+            {
+                var prev = (long)property.GetValue(previous)!;
+                var curr = (long)property.GetValue(rebuilt)!;
+                if (prev > curr)
+                {
+                    property.SetValue(rebuilt, prev);
+                }
+            }
+            else if (property.PropertyType == typeof(bool) && property.CanWrite)
+            {
+                if ((bool)property.GetValue(previous)!)
+                {
+                    property.SetValue(rebuilt, true);
+                }
+            }
+            else if (property.PropertyType == typeof(DateOnly?) && property.CanWrite)
+            {
+                var prev = (DateOnly?)property.GetValue(previous);
+                var curr = (DateOnly?)property.GetValue(rebuilt);
+                if (prev.HasValue && (!curr.HasValue || prev.Value > curr.Value))
+                {
+                    property.SetValue(rebuilt, prev);
+                }
+            }
+            else if (property.GetValue(previous) is HashSet<string> prevStrings && property.GetValue(rebuilt) is HashSet<string> currStrings)
+            {
+                currStrings.UnionWith(prevStrings);
+            }
+            else if (property.GetValue(previous) is HashSet<int> prevInts && property.GetValue(rebuilt) is HashSet<int> currInts)
+            {
+                currInts.UnionWith(prevInts);
+            }
+            else if (property.GetValue(previous) is Dictionary<string, int> prevCounts && property.GetValue(rebuilt) is Dictionary<string, int> currCounts)
+            {
+                foreach (var (key, value) in prevCounts)
+                {
+                    if (!currCounts.TryGetValue(key, out var existing) || value > existing)
+                    {
+                        currCounts[key] = value;
+                    }
+                }
+            }
+            else if (property.GetValue(previous) is Dictionary<string, long> prevLongCounts && property.GetValue(rebuilt) is Dictionary<string, long> currLongCounts)
+            {
+                foreach (var (key, value) in prevLongCounts)
+                {
+                    if (!currLongCounts.TryGetValue(key, out var existing) || value > existing)
+                    {
+                        currLongCounts[key] = value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -1571,11 +1571,85 @@ public class AchievementBadgeService : IDisposable
         userId = NormalizeUserId(userId);
         lock (_lock)
         {
+            _userProfiles.TryGetValue(userId, out var previous);
+
             var profile = CreateProfile(userId);
+            if (previous is not null)
+            {
+                PreserveNonDerivedState(previous, profile);
+            }
+
             _userProfiles[userId] = profile;
             Save();
             _logger.LogInformation("Reset badges for user {UserId}", userId);
             return profile.Badges.Select(CloneBadge).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Carry over everything a watch-history rebuild cannot reconstruct.
+    /// <para>
+    /// The reset exists so the backfill can recompute counters from playback
+    /// history. Counters are therefore left to be rebuilt, which is the point.
+    /// Everything else in the profile was never derived from playback: the
+    /// social graph, the shop inventory, the deliberate showcase, the user's
+    /// settings. Dropping it turns a scan into silent data loss, and the loss
+    /// is unrecoverable because the source it would be rebuilt from does not
+    /// exist.
+    /// </para>
+    /// <para>
+    /// Unlocks are carried over too. An unlock is a historical event, and
+    /// media that has since been deleted from the library can never be
+    /// counted again, so a rebuild would revoke badges the user genuinely
+    /// earned. Admins who need to un-award a badge have <c>RevokeBadge</c>
+    /// and the audit cleanup tool, which are explicit about it.
+    /// </para>
+    /// </summary>
+    private static void PreserveNonDerivedState(UserAchievementProfile previous, UserAchievementProfile profile)
+    {
+        profile.Preferences = previous.Preferences;
+
+        // Deliberate presentation choices.
+        profile.EquippedBadgeIds = new List<string>(previous.EquippedBadgeIds);
+        profile.PinnedBadgeIds = new List<string>(previous.PinnedBadgeIds);
+        profile.EquippedTitleBadgeId = previous.EquippedTitleBadgeId;
+        profile.EquippedThemeId = previous.EquippedThemeId;
+        profile.EquippedBadgeFrameId = previous.EquippedBadgeFrameId;
+        profile.EquippedCustomTitleId = previous.EquippedCustomTitleId;
+        profile.EquippedAvatarId = previous.EquippedAvatarId;
+        profile.EquippedBackgroundId = previous.EquippedBackgroundId;
+        profile.EquippedProfileBorderId = previous.EquippedProfileBorderId;
+
+        // Purchases and prestige. Spending happened; it cannot be replayed.
+        profile.OwnedCosmetics = new List<string>(previous.OwnedCosmetics);
+        profile.BoughtBadgeIds = new List<string>(previous.BoughtBadgeIds);
+        profile.PowerUpInventory = new Dictionary<string, int>(previous.PowerUpInventory);
+        profile.LifetimeScoreSpent = previous.LifetimeScoreSpent;
+        profile.StreakFreezesBanked = previous.StreakFreezesBanked;
+        profile.PrestigeLevel = previous.PrestigeLevel;
+
+        // Social graph. Nothing here comes from playback.
+        profile.Friends = new List<string>(previous.Friends);
+        profile.FriendRequestsSent = new List<string>(previous.FriendRequestsSent);
+        profile.FriendRequestsReceived = new List<string>(previous.FriendRequestsReceived);
+        profile.CompareHistory = new List<CompareHistoryEntry>(previous.CompareHistory);
+
+        // Already-earned badges stay earned.
+        var earned = previous.Badges
+            .Where(b => b.Unlocked)
+            .ToDictionary(b => b.Id, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var badge in profile.Badges)
+        {
+            if (!earned.TryGetValue(badge.Id, out var before))
+            {
+                continue;
+            }
+
+            badge.Unlocked = true;
+            badge.UnlockedAt = before.UnlockedAt;
+            badge.UnlockDeviceId = before.UnlockDeviceId;
+            badge.EarnSource = before.EarnSource;
         }
     }
 

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -1583,6 +1584,54 @@ public class AchievementBadgeService : IDisposable
             Save();
             _logger.LogInformation("Reset badges for user {UserId}", userId);
             return profile.Badges.Select(CloneBadge).ToList();
+        }
+    }
+
+    /// <summary>
+    /// Deep copies the current counters for a user, or null when the user has
+    /// no profile yet. Taken by the backfill right before it resets a profile
+    /// so the rebuilt counters can be floored at their pre scan values (fork
+    /// companion to issue #48, see <see cref="CounterFloor"/>).
+    /// </summary>
+    public UserAchievementCounters? SnapshotCountersForUser(string userId)
+    {
+        userId = NormalizeUserId(userId);
+        lock (_lock)
+        {
+            if (!_userProfiles.TryGetValue(userId, out var profile))
+            {
+                return null;
+            }
+
+            var json = JsonSerializer.Serialize(profile.Counters, _jsonOptions);
+            return JsonSerializer.Deserialize<UserAchievementCounters>(json, _jsonOptions);
+        }
+    }
+
+    /// <summary>
+    /// Floors the user's counters at a snapshot taken before a rebuild, so a
+    /// watch history scan can only move totals forward. Deliberately does not
+    /// re evaluate badge unlocks here: unlocked badges already survive the
+    /// reset, and still locked badges will unlock on the next genuine
+    /// playback event that touches their counter.
+    /// </summary>
+    public void ApplyCounterFloor(string userId, UserAchievementCounters? previous)
+    {
+        if (previous is null)
+        {
+            return;
+        }
+
+        userId = NormalizeUserId(userId);
+        lock (_lock)
+        {
+            if (!_userProfiles.TryGetValue(userId, out var profile))
+            {
+                return;
+            }
+
+            CounterFloor.Apply(previous, profile.Counters);
+            Save();
         }
     }
 
@@ -3605,7 +3654,66 @@ public class AchievementBadgeService : IDisposable
         }
         catch { /* backup is best-effort; don't block the real save */ }
 
+        // Once per UTC day, keep a dated copy of the previous state
+        // under {pluginData}/backups. The .bak above rotates on every save,
+        // so its recovery window is minutes; the dated snapshots let an
+        // accidental scan or a corrupted write be rolled back days later.
+        try
+        {
+            WriteDailySnapshot();
+        }
+        catch { /* snapshot housekeeping must never block the real save */ }
+
         File.Move(tmp, _dataFilePath, overwrite: true);
+    }
+
+    private void WriteDailySnapshot()
+    {
+        var retention = Plugin.Instance?.Configuration?.SnapshotRetentionDays ?? 14;
+        WriteDailySnapshotCore(_dataFilePath, DateOnly.FromDateTime(DateTime.UtcNow), retention);
+    }
+
+    /// <summary>
+    /// Testable core of the daily snapshot: copies the current data file to
+    /// backups/badges-yyyy-MM-dd.json at most once per day, then prunes
+    /// snapshots older than the retention window. Pruning matches by file
+    /// name date, never by file timestamps, so copied or restored files
+    /// behave predictably. A retention of zero disables the feature.
+    /// </summary>
+    public static void WriteDailySnapshotCore(string dataFilePath, DateOnly today, int retentionDays)
+    {
+        if (retentionDays <= 0 || !File.Exists(dataFilePath))
+        {
+            return;
+        }
+
+        var parent = Path.GetDirectoryName(dataFilePath);
+        if (string.IsNullOrEmpty(parent))
+        {
+            return;
+        }
+
+        var dir = Path.Combine(parent, "backups");
+        var snapshot = Path.Combine(dir, "badges-" + today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) + ".json");
+        if (File.Exists(snapshot))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(dir);
+        File.Copy(dataFilePath, snapshot);
+
+        var cutoff = today.AddDays(-retentionDays);
+        foreach (var file in Directory.GetFiles(dir, "badges-*.json"))
+        {
+            var stem = Path.GetFileNameWithoutExtension(file);
+            var datePart = stem.Length > 7 ? stem[7..] : string.Empty;
+            if (DateOnly.TryParseExact(datePart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var fileDate)
+                && fileDate < cutoff)
+            {
+                File.Delete(file);
+            }
+        }
     }
 
     private static int CalendarDaysSinceFirstWatch(UserAchievementCounters c)

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -79,6 +79,13 @@ public class WatchHistoryBackfillService
                 return new { UserId = userId, Username = username, Success = false, Error = "User not found." };
             }
 
+            // Issue #48 companion: capture the counters before the
+            // reset so the rebuild can never move a lifetime total backwards.
+            // Media deleted since it was watched is invisible to the replay
+            // below, and without a floor every total it once fed would
+            // silently shrink.
+            var preScanCounters = _achievementBadgeService.SnapshotCountersForUser(userId);
+
             // Reset badges so we rebuild from watch history
             _achievementBadgeService.ResetBadgesForUser(userId);
 
@@ -263,6 +270,10 @@ public class WatchHistoryBackfillService
                     _logger.LogWarning(ex, "[AchievementBadges] Failed to check series completion for series {SeriesId}.", seriesId);
                 }
             }
+
+            // Issue #48 companion: floor the rebuilt counters at their
+            // pre scan values so deleted media never shrinks lifetime totals.
+            _achievementBadgeService.ApplyCounterFloor(userId, preScanCounters);
 
             _logger.LogInformation(
                 "[AchievementBadges] Backfill done for {Username}: {Movies} movies, {Episodes} episodes, {Series} series, {Books} books, {Libraries} libraries.",


### PR DESCRIPTION
Builds on top of #51 and, together with it, completes #48. The branch includes the #51 commit, so merging #51 first shrinks this diff to the resilience commit alone.

## What was still lossy after #51

#51 keeps everything a rebuild cannot reconstruct: unlocks, the social graph, the shop inventory, the user's settings. Two loss windows remained.

First, counters. The rebuild replays what the library holds today, so media deleted since it was watched is invisible to the replay, and every lifetime total it once fed silently shrinks on the next scan.

Second, the data file itself. badges.json already has a rolling .bak, but it rotates on every save, so the window to recover from a destructive scan or a corrupted write is minutes.

## Counter floor

The backfill snapshots a user's counters before the reset and, once the replay ends, floors the rebuilt counters at their pre scan values: numeric totals and high water marks keep the larger value, sticky holiday flags stay set, distinct value sets union, per key tallies keep the larger count per key, and dates keep the later day. Fields the replay reconstructs completely simply keep the replayed value, because the snapshot holds nothing bigger.

The merge (Helpers/CounterFloor.cs) is reflection based on purpose: counters added by future versions are covered automatically instead of silently escaping the floor. Badge unlock evaluation is deliberately not re run during the floor; unlocked badges already survive the reset via #51, and still locked badges unlock on the next genuine playback event that touches their counter.

## Daily snapshots

On the first save of each UTC day the service copies the current badges.json to {pluginData}/backups/badges-yyyy-MM-dd.json, then prunes snapshots older than a configurable retention (SnapshotRetentionDays, default 14, zero disables). Pruning matches by the date in the file name, never by file timestamps, and touches nothing else in the directory, so foreign files an admin drops there are safe. Snapshot housekeeping is best effort and can never block the real save.

## Tests

Six new tests in DataResilienceTests.cs pin the merge semantics for every field category, the once per day write, the file name based pruning, the zero retention off switch and the config default. 74 of 74 pass on this branch (upstream suite plus the #51 tests plus these).
