### PR TITLE
Carry watch time across sessions of the same item so a broken stream still credits

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -1,0 +1,109 @@
+using System;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Watch time must survive a stream that drops and reconnects mid-item.
+/// <para>
+/// Jellyfin hands a reconnecting client a new session id, and the per-session
+/// accumulator is keyed by that id, so everything watched before the break was
+/// discarded. The trigger is ordinary: when a transcode stalls the client stops
+/// and restarts on its own within seconds, which the viewer sees as buffering.
+/// A full viewing then arrives as two halves and neither reaches the credit
+/// threshold, so nothing is credited at all.
+/// </para>
+/// </summary>
+public class WatchCarryTests
+{
+    private const string User = "5dd06ee5-ced1-4cee-a5e5-cbc29d2425c4";
+    private const string Item = "22f1b2e0-72af-4c24-7bbb-e09d1c6e5042";
+
+    private static readonly DateTimeOffset Now = new(2026, 8, 2, 23, 30, 0, TimeSpan.Zero);
+
+    private static long Seconds(int s) => s * TimeSpan.TicksPerSecond;
+
+    [Fact]
+    public void BrokenStream_IsMeasuredAsOneViewing_NotTwoHalves()
+    {
+        // The real incident: a 3777s episode watched in full, split by a
+        // transcode stall into 1664s and 2234s. Eighteen seconds passed
+        // between the two sessions.
+        const long runtime = 3777L * TimeSpan.TicksPerSecond;
+        var store = new WatchCarryStore();
+
+        var firstSession = Seconds(1664);
+        Assert.Equal(0, store.Peek(User, Item, Now));
+        Assert.True(firstSession * 100d / runtime < 80d, "the first half alone must not reach the threshold");
+        store.Remember(User, Item, firstSession, Now);
+
+        var reconnect = Now.AddSeconds(18);
+        var secondSession = Seconds(2234);
+        Assert.True(secondSession * 100d / runtime < 80d, "the second half alone must not reach the threshold either");
+
+        var total = secondSession + store.Peek(User, Item, reconnect);
+        var completion = total * 100d / runtime;
+
+        Assert.True(completion >= 80d, $"the full viewing must credit, got {completion:0.##}%");
+        Assert.True(completion > 100d, "1664s plus 2234s exceeds the 3777s runtime");
+    }
+
+    [Fact]
+    public void CreditedItem_StartsFromZeroOnTheNextViewing()
+    {
+        var store = new WatchCarryStore();
+        store.Remember(User, Item, Seconds(1664), Now);
+        Assert.Equal(Seconds(1664), store.Peek(User, Item, Now));
+
+        store.Clear(User, Item);
+
+        Assert.Equal(0, store.Peek(User, Item, Now.AddMinutes(1)));
+    }
+
+    [Fact]
+    public void CarryExpires_SoAnUnrelatedViewingStartsClean()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromHours(6));
+        store.Remember(User, Item, Seconds(1664), Now);
+
+        Assert.Equal(Seconds(1664), store.Peek(User, Item, Now.AddHours(5)));
+        Assert.Equal(0, store.Peek(User, Item, Now.AddHours(7)));
+    }
+
+    [Fact]
+    public void ExpiredEntries_ArePrunedInsteadOfAccumulating()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromHours(6));
+        for (var i = 0; i < 25; i++)
+        {
+            store.Remember(User, "item-" + i, Seconds(60), Now);
+        }
+
+        Assert.Equal(25, store.Count);
+
+        store.Peek(User, "anything", Now.AddHours(7));
+
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public void CarryIsPerUserAndItem()
+    {
+        var store = new WatchCarryStore();
+        store.Remember(User, Item, Seconds(1000), Now);
+
+        Assert.Equal(0, store.Peek("99999999-9999-9999-9999-999999999999", Item, Now));
+        Assert.Equal(0, store.Peek(User, "another-item", Now));
+        Assert.Equal(Seconds(1000), store.Peek(User, Item, Now));
+    }
+
+    [Fact]
+    public void NonPositiveTicks_DoNotCreateAnEntry()
+    {
+        var store = new WatchCarryStore();
+        store.Remember(User, Item, 0, Now);
+
+        Assert.Equal(0, store.Count);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// Remembers watch time that ended a session without being credited, keyed by
+/// user and item, so the next session for the same item continues from it.
+/// <para>
+/// The per-session accumulator in <c>PlaybackCompletionTracker</c> is keyed by
+/// Jellyfin's session id, and a stream that drops and reconnects is handed a
+/// brand new one, so everything watched before the break was discarded. That
+/// is not an edge case: when a transcode stalls, the client stops and restarts
+/// on its own within seconds, which the viewer experiences as buffering rather
+/// than an interruption. An episode watched end to end could therefore be
+/// measured as two halves, neither one reaching the credit threshold, and no
+/// credit was given for a full viewing.
+/// </para>
+/// <para>
+/// This does not weaken the anti-abuse gate. Only genuinely advanced playback
+/// time is ever accumulated, because seeks are excluded before the ticks get
+/// here; the carry expires after the window; and it is dropped as soon as the
+/// item is credited, so a later re-watch starts from zero.
+/// </para>
+/// </summary>
+public sealed class WatchCarryStore
+{
+    private sealed class Entry
+    {
+        public long Ticks;
+        public DateTimeOffset UpdatedAt;
+    }
+
+    private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TimeSpan _window;
+
+    /// <summary>
+    /// Creates a store. The default window is six hours: long enough to cover
+    /// a viewing interrupted by repeated reconnects, short enough that an
+    /// unrelated viewing days later starts clean.
+    /// </summary>
+    public WatchCarryStore(TimeSpan? window = null)
+    {
+        _window = window ?? TimeSpan.FromHours(6);
+    }
+
+    /// <summary>Number of entries currently held. Diagnostics and tests.</summary>
+    public int Count => _entries.Count;
+
+    private static string Key(string userId, string itemId) => userId + "|" + itemId;
+
+    /// <summary>
+    /// Ticks carried for this user and item, or zero when there is nothing
+    /// recent. Expired entries are dropped on the way through, which keeps the
+    /// store bounded without a background timer.
+    /// </summary>
+    public long Peek(string userId, string itemId, DateTimeOffset now)
+    {
+        Prune(now);
+
+        if (_entries.TryGetValue(Key(userId, itemId), out var entry)
+            && now - entry.UpdatedAt <= _window)
+        {
+            return entry.Ticks;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Records ticks watched but not credited. Replaces any previous value,
+    /// because the caller passes the running total for the item, not a delta.
+    /// Non-positive values clear the entry instead of storing a useless one.
+    /// </summary>
+    public void Remember(string userId, string itemId, long ticks, DateTimeOffset now)
+    {
+        if (ticks <= 0)
+        {
+            Clear(userId, itemId);
+            return;
+        }
+
+        _entries[Key(userId, itemId)] = new Entry { Ticks = ticks, UpdatedAt = now };
+    }
+
+    /// <summary>Drops the carry, called once the item has been credited.</summary>
+    public void Clear(string userId, string itemId)
+    {
+        _entries.TryRemove(Key(userId, itemId), out _);
+    }
+
+    private void Prune(DateTimeOffset now)
+    {
+        foreach (var pair in _entries)
+        {
+            if (now - pair.Value.UpdatedAt > _window)
+            {
+                _entries.TryRemove(pair.Key, out _);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Jellyfin.Plugin.AchievementBadges.Models;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -46,6 +47,10 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         public int ProgressEventCount;
     }
     private readonly ConcurrentDictionary<string, SessionWatchState> _sessions = new();
+
+    // Watch time carried across sessions for the same item, so a stream that
+    // breaks and reconnects is measured as one viewing. See WatchCarryStore.
+    private readonly WatchCarryStore _carried = new();
 
     public PlaybackCompletionTracker(
         ISessionManager sessionManager,
@@ -302,6 +307,24 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
                 progressEventCount = session.ProgressEventCount;
             }
 
+            // Fold in anything watched for this item in an earlier session that
+            // ended without credit, so a stream that broke and reconnected is
+            // measured as one viewing. See WatchCarryStore for why this is safe.
+            var now = DateTimeOffset.UtcNow;
+            var carriedTicks = _carried.Peek(userId, itemId, now);
+            if (carriedTicks > 0)
+            {
+                _logger.LogInformation(
+                    "[AchievementBadges] {Source} for user {UserId} item {ItemId}: adding {Carried}s carried from an earlier session of the same item to this session's {Session}s.",
+                    source,
+                    userId,
+                    itemId,
+                    carriedTicks / TimeSpan.TicksPerSecond,
+                    accumulatedPlayTicks / TimeSpan.TicksPerSecond);
+
+                accumulatedPlayTicks += carriedTicks;
+            }
+
             double completionPercent;
             if (runTimeTicks > 0)
             {
@@ -378,12 +401,20 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
 
             if (success)
             {
+                // Credited, so a later viewing of the same item starts clean.
+                _carried.Clear(userId, itemId);
+
                 _logger.LogInformation(
                     "[AchievementBadges] Recorded playback from {Source} user={UserId} item={ItemId} library={Library} completion={Completion:0.##}%",
                     source, userId, itemId, libraryName ?? "(none)", completionPercent);
             }
             else
             {
+                // Not credited: remember what was genuinely watched so a
+                // reconnect can pick up where this session left off instead of
+                // starting from zero.
+                _carried.Remember(userId, itemId, accumulatedPlayTicks, now);
+
                 _logger.LogDebug(
                     "[AchievementBadges] Skipped playback from {Source} user={UserId} item={ItemId} reason={Reason}",
                     source, userId, itemId, message);


### PR DESCRIPTION
Fixes #61. Branches from v2.2.0 and touches one service plus one new helper, so it applies independently of the other open pull requests.

## The defect

`PlaybackCompletionTracker` accumulates real playback time keyed by Jellyfin's session id, and reads exactly one session on stop:

```csharp
if (!string.IsNullOrWhiteSpace(sessionId)
    && _sessions.TryRemove(sessionId, out var session))
{
    accumulatedPlayTicks = session.AccumulatedPlayTicks;
```

A reconnecting client gets a new session id, so a stream that drops mid item restarts the accumulator at zero and only the remainder is compared against the full runtime. Below the `completionPercent < 80` gate nothing is credited, and an item watched end to end can credit nothing at all.

The trigger is ordinary rather than exotic. When a transcode stalls, the client stops and restarts on its own within seconds, which the viewer experiences as buffering. On my server a 3777 second episode watched in full arrived as 1664s and 2234s eighteen seconds apart, and the log recorded 59.14%, which is exactly 2234 / 3777. Seven refusals and zero credits over three days, all from the same cause.

## The change

A small `WatchCarryStore` holds ticks that ended a session without credit, keyed by user and item. The tracker folds any recent carry into the current session before computing the percentage, clears it once the item is credited, and remembers the running total when it is not.

The anti-abuse gate is untouched. Only genuinely advanced playback time reaches the store, because seeks are already excluded by the `delta <= MaxGoodDeltaTicks` filter, so this cannot be used to accumulate credit by seeking. Clearing on credit keeps a later re-watch honest. The carry expires after six hours and expired entries are pruned on read, so the store stays bounded without a background timer.

Six hours is long enough to cover a viewing broken by repeated reconnects and short enough that an unrelated viewing days later starts clean. It is a `TimeSpan` constructor parameter if you would rather it be configurable.

## Tests

`WatchCarryTests.cs`. The first test replays the real incident: 1664s then 2234s against a 3777s runtime, asserting that each half alone stays under the threshold and the combined viewing clears it. The rest cover clearing on credit, expiry, pruning, per user and per item isolation, and that non-positive ticks never create an entry. 73 of 73 pass.

## Note on the log wording

The refusal is logged at Information level as "Refusing credit; this is the expected behavior for seek-to-end / mark-as-played / 0-second-watch attempts". While this bug is present that line also fires for honest viewings, so an admin reading the log sees what looks like an anti-abuse success and has no reason to investigate. Worth softening once the underlying cause is fixed.
