### PR TITLE
Read the live watch streak in quests instead of the all-time best

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/QuestMetricTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/QuestMetricTests.cs
@@ -1,0 +1,84 @@
+using System;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// The weekly "Daily Dedication" quest asks the user to maintain a five day
+/// watch streak, and quest progress is the metric minus the value captured
+/// when the period began. Reading <c>BestWatchStreak</c> instead of the live
+/// streak makes that impossible for anyone with an established record: the
+/// all-time best only rises above its own captured value on a new personal
+/// record, so a user watching every day sees 0 progress indefinitely.
+/// </summary>
+public class QuestMetricTests
+{
+    private static UserAchievementCounters WithWatchDates(params string[] dates)
+    {
+        var counters = new UserAchievementCounters();
+        foreach (var d in dates)
+        {
+            counters.WatchDates.Add(d);
+        }
+
+        return counters;
+    }
+
+    [Fact]
+    public void CurrentWatchStreak_ReflectsTheLiveStreak_NotTheAllTimeBest()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counters = WithWatchDates(
+            today.AddDays(-3).ToString("yyyy-MM-dd"),
+            today.AddDays(-2).ToString("yyyy-MM-dd"),
+            today.AddDays(-1).ToString("yyyy-MM-dd"),
+            today.ToString("yyyy-MM-dd"));
+
+        // An old record far above the current run: the value the quest used to
+        // read, and the reason progress stayed at zero.
+        counters.BestWatchStreak = 42;
+
+        var live = AchievementBadgeService.GetCurrentWatchStreak(counters);
+
+        Assert.Equal(4, live);
+        Assert.NotEqual(counters.BestWatchStreak, live);
+    }
+
+    [Fact]
+    public void StreakRunsFromTheMostRecentDay_AndStopsAtTheFirstGap()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counters = WithWatchDates(
+            today.AddDays(-9).ToString("yyyy-MM-dd"),  // isolated, before the gap
+            today.AddDays(-3).ToString("yyyy-MM-dd"),
+            today.AddDays(-2).ToString("yyyy-MM-dd"),
+            today.AddDays(-1).ToString("yyyy-MM-dd"));
+        counters.BestWatchStreak = 40;
+
+        // Three consecutive days ending yesterday. The isolated day nine days
+        // back is on the far side of a gap and does not extend it, and the
+        // stale record does not inflate it.
+        Assert.Equal(3, AchievementBadgeService.GetCurrentWatchStreak(counters));
+    }
+
+    [Fact]
+    public void DuplicateDates_DoNotInflateTheStreak()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counters = WithWatchDates(
+            today.AddDays(-1).ToString("yyyy-MM-dd"),
+            today.ToString("yyyy-MM-dd"));
+
+        Assert.Equal(2, AchievementBadgeService.GetCurrentWatchStreak(counters));
+    }
+
+    [Fact]
+    public void NoWatchDates_ReportsZero_EvenWithARecord()
+    {
+        var counters = new UserAchievementCounters { BestWatchStreak = 12 };
+
+        Assert.Equal(0, AchievementBadgeService.GetCurrentWatchStreak(counters));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -3150,7 +3150,12 @@ public class AchievementBadgeService : IDisposable
         return result;
     }
 
-    private static int GetCurrentWatchStreak(UserAchievementCounters counters)
+    /// <summary>
+    /// Consecutive days of watch activity ending at the most recent one.
+    /// Public so QuestService can read the same number the profile shows
+    /// instead of substituting the all-time best.
+    /// </summary>
+    public static int GetCurrentWatchStreak(UserAchievementCounters counters)
     {
         if (counters.WatchDates.Count == 0)
         {

--- a/Jellyfin.Plugin.AchievementBadges/Services/QuestService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/QuestService.cs
@@ -347,7 +347,12 @@ public class QuestService
             AchievementMetric.UniqueGenresWatched => counters.UniqueGenresWatched,
             AchievementMetric.RewatchCount => counters.RewatchCount,
             AchievementMetric.TotalMinutesWatched => counters.TotalMinutesWatched > int.MaxValue ? int.MaxValue : (int)counters.TotalMinutesWatched,
-            AchievementMetric.CurrentWatchStreak => counters.BestWatchStreak,
+            // Read the live streak, not the all-time best. Quest progress is
+            // the metric minus the value captured when the period began, and
+            // BestWatchStreak only rises above its own captured value on a new
+            // personal record, so this quest asked the user to beat their own
+            // record by the target rather than to hold a streak of it.
+            AchievementMetric.CurrentWatchStreak => AchievementBadgeService.GetCurrentWatchStreak(counters),
             AchievementMetric.SeriesCompleted => counters.SeriesCompleted,
             AchievementMetric.LongestItemMinutes => counters.LongestItemMinutes,
             AchievementMetric.ShortItemsWatched => counters.ShortItemsWatched,


### PR DESCRIPTION
Fixes #63. Branches from v2.2.0 and changes one mapping plus one accessibility modifier, so it applies independently of the other open pull requests.

## The defect

`QuestService.GetCounterValue` resolves the streak metric to the all-time record:

```csharp
AchievementMetric.CurrentWatchStreak => counters.BestWatchStreak,
```

while `AchievementBadgeService` resolves the same metric to the live value, which is what the profile card shows.

Because quest progress is `metric - StartValue` and `BestWatchStreak` is monotonic, the value only rises above the one captured at the start of the period when the user sets a **new personal record**. So "Maintain a 5-day watch streak" actually asks the user to beat their own record by five inside one week. A record of 6 means reaching 11 that week; a record of 40 makes it unreachable. Watching every day of the week moves the bar not at all.

Observed on my server: a live 8-day streak displayed on the profile, and the quest sitting at 0 of 5, with the stored state showing `StartValue: 6`, which was `BestWatchStreak` rather than the live streak.

## The change

Quests now read the same helper the profile reads:

```csharp
AchievementMetric.CurrentWatchStreak => AchievementBadgeService.GetCurrentWatchStreak(counters),
```

`GetCurrentWatchStreak` becomes public. It already backs the summary endpoint, so this only widens access to a value the API surface exposes anyway.

## Tests

`QuestMetricTests.cs` pins the live streak against a stale record: consecutive days ending at the most recent watch, stopping at the first gap, ignoring a much larger `BestWatchStreak`, duplicates not inflating the count, and an empty history reporting zero rather than the record. 71 of 71 pass.

## Note on the delta model

Fixing the mapping makes the quest completable, but a state metric under a delta model still behaves oddly: a user who starts the week already on a 4-day streak has to reach 9 rather than 5. Treating state metrics as absolute thresholds would match the quest text more closely. I left that out of this change since it alters quest semantics rather than fixing a mismatch, but I am happy to send it separately if you want it.
