### PR TITLE
Carry uncredited watch time for days, and across restarts

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -1,0 +1,109 @@
+using System;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Watch time must survive a stream that drops and reconnects mid-item.
+/// <para>
+/// Jellyfin hands a reconnecting client a new session id, and the per-session
+/// accumulator is keyed by that id, so everything watched before the break was
+/// discarded. The trigger is ordinary: when a transcode stalls the client stops
+/// and restarts on its own within seconds, which the viewer sees as buffering.
+/// A full viewing then arrives as two halves and neither reaches the credit
+/// threshold, so nothing is credited at all.
+/// </para>
+/// </summary>
+public class WatchCarryTests
+{
+    private const string User = "5dd06ee5-ced1-4cee-a5e5-cbc29d2425c4";
+    private const string Item = "22f1b2e0-72af-4c24-7bbb-e09d1c6e5042";
+
+    private static readonly DateTimeOffset Now = new(2026, 8, 2, 23, 30, 0, TimeSpan.Zero);
+
+    private static long Seconds(int s) => s * TimeSpan.TicksPerSecond;
+
+    [Fact]
+    public void BrokenStream_IsMeasuredAsOneViewing_NotTwoHalves()
+    {
+        // The real incident: a 3777s episode watched in full, split by a
+        // transcode stall into 1664s and 2234s. Eighteen seconds passed
+        // between the two sessions.
+        const long runtime = 3777L * TimeSpan.TicksPerSecond;
+        var store = new WatchCarryStore();
+
+        var firstSession = Seconds(1664);
+        Assert.Equal(0, store.Peek(User, Item, Now));
+        Assert.True(firstSession * 100d / runtime < 80d, "the first half alone must not reach the threshold");
+        store.Remember(User, Item, firstSession, Now);
+
+        var reconnect = Now.AddSeconds(18);
+        var secondSession = Seconds(2234);
+        Assert.True(secondSession * 100d / runtime < 80d, "the second half alone must not reach the threshold either");
+
+        var total = secondSession + store.Peek(User, Item, reconnect);
+        var completion = total * 100d / runtime;
+
+        Assert.True(completion >= 80d, $"the full viewing must credit, got {completion:0.##}%");
+        Assert.True(completion > 100d, "1664s plus 2234s exceeds the 3777s runtime");
+    }
+
+    [Fact]
+    public void CreditedItem_StartsFromZeroOnTheNextViewing()
+    {
+        var store = new WatchCarryStore();
+        store.Remember(User, Item, Seconds(1664), Now);
+        Assert.Equal(Seconds(1664), store.Peek(User, Item, Now));
+
+        store.Clear(User, Item);
+
+        Assert.Equal(0, store.Peek(User, Item, Now.AddMinutes(1)));
+    }
+
+    [Fact]
+    public void CarryExpires_SoAnUnrelatedViewingStartsClean()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromHours(6));
+        store.Remember(User, Item, Seconds(1664), Now);
+
+        Assert.Equal(Seconds(1664), store.Peek(User, Item, Now.AddHours(5)));
+        Assert.Equal(0, store.Peek(User, Item, Now.AddHours(7)));
+    }
+
+    [Fact]
+    public void ExpiredEntries_ArePrunedInsteadOfAccumulating()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromHours(6));
+        for (var i = 0; i < 25; i++)
+        {
+            store.Remember(User, "item-" + i, Seconds(60), Now);
+        }
+
+        Assert.Equal(25, store.Count);
+
+        store.Peek(User, "anything", Now.AddHours(7));
+
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public void CarryIsPerUserAndItem()
+    {
+        var store = new WatchCarryStore();
+        store.Remember(User, Item, Seconds(1000), Now);
+
+        Assert.Equal(0, store.Peek("99999999-9999-9999-9999-999999999999", Item, Now));
+        Assert.Equal(0, store.Peek(User, "another-item", Now));
+        Assert.Equal(Seconds(1000), store.Peek(User, Item, Now));
+    }
+
+    [Fact]
+    public void NonPositiveTicks_DoNotCreateAnEntry()
+    {
+        var store = new WatchCarryStore();
+        store.Remember(User, Item, 0, Now);
+
+        Assert.Equal(0, store.Count);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Jellyfin.Plugin.AchievementBadges;
 using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Xunit;
 
@@ -105,5 +106,161 @@ public class WatchCarryTests
         store.Remember(User, Item, 0, Now);
 
         Assert.Equal(0, store.Count);
+    }
+
+    // ─── A long item watched across the day, not across a reconnect ───────
+    //
+    // The reconnect case above spans seconds. The pattern that actually costs
+    // users their credit spans hours: a two-hour episode watched in pieces
+    // between other things. A six-hour window was sized for the reconnect and
+    // silently drops these, so an item genuinely watched end to end is refused.
+
+    private const string LongItem = "95a4e374-411e-2fa2-c601-116b4b59a10e";
+
+    [Fact]
+    public void ItemWatchedInPiecesAcrossTheDay_StillCredits()
+    {
+        // Real timeline: a 8283s episode, five sittings from 09:47 to 21:01.
+        const long runtime = 8283L * TimeSpan.TicksPerSecond;
+        var store = new WatchCarryStore();
+        var morning = new DateTimeOffset(2026, 8, 3, 9, 47, 0, TimeSpan.Zero);
+
+        store.Remember(User, LongItem, Seconds(1105), morning);
+        store.Remember(User, LongItem, Seconds(2554), morning.AddHours(1.5));
+        store.Remember(User, LongItem, Seconds(2957), morning.AddHours(2.6));
+        store.Remember(User, LongItem, Seconds(4426), morning.AddHours(4.4));
+
+        // The last sitting ended 6h49m after the one before it.
+        var lastStop = morning.AddHours(11.2);
+        var carried = store.Peek(User, LongItem, lastStop);
+        var total = carried + Seconds(5000);
+
+        Assert.True(
+            total * 100d / runtime >= 80d,
+            $"an episode watched to the end across the day must credit, got {total * 100d / runtime:0.##}%");
+    }
+
+    [Fact]
+    public void SixHourWindow_WasTooShortForThatPattern()
+    {
+        // Pins why the default changed: the same timeline under the old window
+        // discards everything watched before the gap.
+        var store = new WatchCarryStore(TimeSpan.FromHours(6));
+        var start = new DateTimeOffset(2026, 8, 3, 14, 12, 0, TimeSpan.Zero);
+        store.Remember(User, LongItem, Seconds(4426), start);
+
+        Assert.Equal(0, store.Peek(User, LongItem, start.AddHours(6.82)));
+    }
+
+    [Fact]
+    public void DefaultWindow_CoversAnItemLeftAndResumedDaysLater()
+    {
+        // Also real: one episode spread over 29/07, 30/07 and 01/08.
+        var store = new WatchCarryStore();
+        store.Remember(User, LongItem, Seconds(3000), Now);
+
+        Assert.Equal(Seconds(3000), store.Peek(User, LongItem, Now.AddDays(3)));
+        Assert.Equal(Seconds(3000), store.Peek(User, LongItem, Now.AddDays(6)));
+        Assert.Equal(0, store.Peek(User, LongItem, Now.AddDays(8)));
+    }
+
+    // ─── Surviving a restart ──────────────────────────────────────────────
+    //
+    // The store lived only in memory, so restarting Jellyfin threw away every
+    // partial viewing on the server. Over a window measured in days that is no
+    // longer an acceptable loss.
+
+    private static string TempFile() =>
+        System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ab-carry-" + Guid.NewGuid().ToString("N") + ".json");
+
+    // Reading the file back drops entries that expired while the server was
+    // down, and it can only judge that against the real clock. These cases are
+    // therefore anchored to now rather than to a fixed date, which would start
+    // failing on its own once the date fell outside the window.
+    private static readonly DateTimeOffset Recently = DateTimeOffset.UtcNow.AddHours(-1);
+
+    [Fact]
+    public void Carry_SurvivesARestart()
+    {
+        var path = TempFile();
+        try
+        {
+            var before = new WatchCarryStore(persistPath: path);
+            before.Remember(User, LongItem, Seconds(4426), Recently);
+
+            var afterRestart = new WatchCarryStore(persistPath: path);
+
+            Assert.Equal(Seconds(4426), afterRestart.Peek(User, LongItem, Recently.AddHours(8)));
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void RestartDoesNotResurrectExpiredCarry()
+    {
+        var path = TempFile();
+        try
+        {
+            var before = new WatchCarryStore(TimeSpan.FromHours(6), path);
+            before.Remember(User, LongItem, Seconds(4426), Recently.AddHours(-9));
+
+            var afterRestart = new WatchCarryStore(TimeSpan.FromHours(6), path);
+
+            Assert.Equal(0, afterRestart.Peek(User, LongItem, Recently));
+            Assert.Equal(0, afterRestart.Count);
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void CreditedItem_StaysClearedAcrossARestart()
+    {
+        var path = TempFile();
+        try
+        {
+            var before = new WatchCarryStore(persistPath: path);
+            before.Remember(User, LongItem, Seconds(4426), Recently);
+            before.Clear(User, LongItem);
+
+            var afterRestart = new WatchCarryStore(persistPath: path);
+
+            Assert.Equal(0, afterRestart.Peek(User, LongItem, Recently));
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void RetentionDefaultsToSevenDays()
+    {
+        Assert.Equal(7, new Configuration.PluginConfiguration().WatchCarryRetentionDays);
+    }
+
+    [Fact]
+    public void UnreadableCarryFile_StartsEmptyInsteadOfThrowing()
+    {
+        var path = TempFile();
+        try
+        {
+            System.IO.File.WriteAllText(path, "{ this is not json");
+
+            var store = new WatchCarryStore(persistPath: path);
+
+            Assert.Equal(0, store.Count);
+            store.Remember(User, LongItem, Seconds(60), Recently);
+            Assert.Equal(Seconds(60), new WatchCarryStore(persistPath: path).Peek(User, LongItem, Recently));
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
     }
 }

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
@@ -65,6 +65,14 @@ public class PluginConfiguration : BasePluginConfiguration
     /// proper day-bucketing for retroactive credit.</summary>
     public bool BackfillSkipTimeWindowedBadges { get; set; } = true;
 
+    /// <summary>For how many days watch time on an item that was not credited
+    /// is carried into the next session of that same item, so a long item taken
+    /// up over several sittings is measured as one viewing. Only genuinely
+    /// advanced playback is ever carried, and the carry is dropped the moment
+    /// the item is credited. Zero disables carrying. Default 7. Applied when
+    /// the tracker starts, so a change takes effect on the next restart.</summary>
+    public int WatchCarryRetentionDays { get; set; } = 7;
+
     public string? WebhookUrl { get; set; }
 
     public bool WebhookEnabled { get; set; }

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
 
 namespace Jellyfin.Plugin.AchievementBadges.Helpers;
 
@@ -17,6 +20,14 @@ namespace Jellyfin.Plugin.AchievementBadges.Helpers;
 /// credit was given for a full viewing.
 /// </para>
 /// <para>
+/// The same discarding hits a much more ordinary habit: a long episode watched
+/// in pieces between other things. A two-hour episode taken in five sittings
+/// across a day, or left and resumed two days later, is one viewing to the
+/// person watching it, and every sitting but the last was being thrown away.
+/// The window is therefore measured in days, and the carry is persisted, since
+/// over that span a restart is expected rather than exceptional.
+/// </para>
+/// <para>
 /// This does not weaken the anti-abuse gate. Only genuinely advanced playback
 /// time is ever accumulated, because seeks are excluded before the ticks get
 /// here; the carry expires after the window; and it is dropped as soon as the
@@ -27,25 +38,50 @@ public sealed class WatchCarryStore
 {
     private sealed class Entry
     {
-        public long Ticks;
-        public DateTimeOffset UpdatedAt;
+        public string UserId { get; set; } = string.Empty;
+
+        public string ItemId { get; set; } = string.Empty;
+
+        public long Ticks { get; set; }
+
+        public DateTimeOffset UpdatedAt { get; set; }
     }
+
+    private sealed class CarryFile
+    {
+        public List<Entry> Entries { get; set; } = new();
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = true };
 
     private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
     private readonly TimeSpan _window;
+    private readonly string? _persistPath;
+    private readonly object _fileLock = new();
 
     /// <summary>
-    /// Creates a store. The default window is six hours: long enough to cover
-    /// a viewing interrupted by repeated reconnects, short enough that an
-    /// unrelated viewing days later starts clean.
+    /// Creates a store. The default window is seven days: long enough for an
+    /// item taken up over several evenings, short enough that an unrelated
+    /// viewing weeks later starts clean. Pass <paramref name="persistPath"/> to
+    /// keep the carry across restarts.
     /// </summary>
-    public WatchCarryStore(TimeSpan? window = null)
+    public WatchCarryStore(TimeSpan? window = null, string? persistPath = null)
     {
-        _window = window ?? TimeSpan.FromHours(6);
+        _window = window ?? TimeSpan.FromDays(7);
+        _persistPath = persistPath;
+        Load();
     }
 
     /// <summary>Number of entries currently held. Diagnostics and tests.</summary>
     public int Count => _entries.Count;
+
+    /// <summary>
+    /// Why the last read or write of the carry file failed, or null when the
+    /// last one succeeded. Callers surface this instead of the store swallowing
+    /// it: a persistence layer that fails quietly loses data without anyone
+    /// noticing, which is the very failure this store exists to prevent.
+    /// </summary>
+    public string? LastPersistError { get; private set; }
 
     private static string Key(string userId, string itemId) => userId + "|" + itemId;
 
@@ -80,23 +116,128 @@ public sealed class WatchCarryStore
             return;
         }
 
-        _entries[Key(userId, itemId)] = new Entry { Ticks = ticks, UpdatedAt = now };
+        _entries[Key(userId, itemId)] = new Entry
+        {
+            UserId = userId,
+            ItemId = itemId,
+            Ticks = ticks,
+            UpdatedAt = now
+        };
+
+        Persist();
     }
 
     /// <summary>Drops the carry, called once the item has been credited.</summary>
     public void Clear(string userId, string itemId)
     {
-        _entries.TryRemove(Key(userId, itemId), out _);
+        if (_entries.TryRemove(Key(userId, itemId), out _))
+        {
+            Persist();
+        }
     }
 
     private void Prune(DateTimeOffset now)
     {
+        var removed = false;
         foreach (var pair in _entries)
         {
             if (now - pair.Value.UpdatedAt > _window)
             {
-                _entries.TryRemove(pair.Key, out _);
+                removed |= _entries.TryRemove(pair.Key, out _);
             }
+        }
+
+        if (removed)
+        {
+            Persist();
+        }
+    }
+
+    private void Load()
+    {
+        if (string.IsNullOrWhiteSpace(_persistPath) || !File.Exists(_persistPath))
+        {
+            return;
+        }
+
+        try
+        {
+            CarryFile? file;
+            lock (_fileLock)
+            {
+                file = JsonSerializer.Deserialize<CarryFile>(File.ReadAllText(_persistPath));
+            }
+
+            if (file?.Entries is null)
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            foreach (var entry in file.Entries)
+            {
+                // An entry that expired while the server was down must not come
+                // back to life just because it was on disk.
+                if (entry is null
+                    || entry.Ticks <= 0
+                    || string.IsNullOrWhiteSpace(entry.UserId)
+                    || string.IsNullOrWhiteSpace(entry.ItemId)
+                    || now - entry.UpdatedAt > _window)
+                {
+                    continue;
+                }
+
+                _entries[Key(entry.UserId, entry.ItemId)] = entry;
+            }
+
+            LastPersistError = null;
+        }
+        catch (Exception ex)
+        {
+            // A carry file we cannot read costs partial viewings, not data the
+            // user owns, so starting empty is the right call. It is reported
+            // rather than hidden, and the next write replaces the bad file.
+            LastPersistError = "read " + _persistPath + ": " + ex.Message;
+        }
+    }
+
+    private void Persist()
+    {
+        if (string.IsNullOrWhiteSpace(_persistPath))
+        {
+            return;
+        }
+
+        try
+        {
+            var file = new CarryFile();
+            foreach (var pair in _entries)
+            {
+                file.Entries.Add(pair.Value);
+            }
+
+            var json = JsonSerializer.Serialize(file, SerializerOptions);
+
+            lock (_fileLock)
+            {
+                var directory = Path.GetDirectoryName(_persistPath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                // Written aside and moved into place so a shutdown mid-write
+                // cannot leave a truncated file to be discarded on boot.
+                var temporary = _persistPath + ".tmp";
+                File.WriteAllText(temporary, json);
+                File.Move(temporary, _persistPath, overwrite: true);
+            }
+
+            LastPersistError = null;
+        }
+        catch (Exception ex)
+        {
+            LastPersistError = "write " + _persistPath + ": " + ex.Message;
         }
     }
 }

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// Remembers watch time that ended a session without being credited, keyed by
+/// user and item, so the next session for the same item continues from it.
+/// <para>
+/// The per-session accumulator in <c>PlaybackCompletionTracker</c> is keyed by
+/// Jellyfin's session id, and a stream that drops and reconnects is handed a
+/// brand new one, so everything watched before the break was discarded. That
+/// is not an edge case: when a transcode stalls, the client stops and restarts
+/// on its own within seconds, which the viewer experiences as buffering rather
+/// than an interruption. An episode watched end to end could therefore be
+/// measured as two halves, neither one reaching the credit threshold, and no
+/// credit was given for a full viewing.
+/// </para>
+/// <para>
+/// This does not weaken the anti-abuse gate. Only genuinely advanced playback
+/// time is ever accumulated, because seeks are excluded before the ticks get
+/// here; the carry expires after the window; and it is dropped as soon as the
+/// item is credited, so a later re-watch starts from zero.
+/// </para>
+/// </summary>
+public sealed class WatchCarryStore
+{
+    private sealed class Entry
+    {
+        public long Ticks;
+        public DateTimeOffset UpdatedAt;
+    }
+
+    private readonly ConcurrentDictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TimeSpan _window;
+
+    /// <summary>
+    /// Creates a store. The default window is six hours: long enough to cover
+    /// a viewing interrupted by repeated reconnects, short enough that an
+    /// unrelated viewing days later starts clean.
+    /// </summary>
+    public WatchCarryStore(TimeSpan? window = null)
+    {
+        _window = window ?? TimeSpan.FromHours(6);
+    }
+
+    /// <summary>Number of entries currently held. Diagnostics and tests.</summary>
+    public int Count => _entries.Count;
+
+    private static string Key(string userId, string itemId) => userId + "|" + itemId;
+
+    /// <summary>
+    /// Ticks carried for this user and item, or zero when there is nothing
+    /// recent. Expired entries are dropped on the way through, which keeps the
+    /// store bounded without a background timer.
+    /// </summary>
+    public long Peek(string userId, string itemId, DateTimeOffset now)
+    {
+        Prune(now);
+
+        if (_entries.TryGetValue(Key(userId, itemId), out var entry)
+            && now - entry.UpdatedAt <= _window)
+        {
+            return entry.Ticks;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Records ticks watched but not credited. Replaces any previous value,
+    /// because the caller passes the running total for the item, not a delta.
+    /// Non-positive values clear the entry instead of storing a useless one.
+    /// </summary>
+    public void Remember(string userId, string itemId, long ticks, DateTimeOffset now)
+    {
+        if (ticks <= 0)
+        {
+            Clear(userId, itemId);
+            return;
+        }
+
+        _entries[Key(userId, itemId)] = new Entry { Ticks = ticks, UpdatedAt = now };
+    }
+
+    /// <summary>Drops the carry, called once the item has been credited.</summary>
+    public void Clear(string userId, string itemId)
+    {
+        _entries.TryRemove(Key(userId, itemId), out _);
+    }
+
+    private void Prune(DateTimeOffset now)
+    {
+        foreach (var pair in _entries)
+        {
+            if (now - pair.Value.UpdatedAt > _window)
+            {
+                _entries.TryRemove(pair.Key, out _);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Jellyfin.Plugin.AchievementBadges.Models;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
@@ -48,11 +50,15 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
     }
     private readonly ConcurrentDictionary<string, SessionWatchState> _sessions = new();
 
-    // Watch time carried across sessions for the same item, so a stream that
-    // breaks and reconnects is measured as one viewing. See WatchCarryStore.
-    private readonly WatchCarryStore _carried = new();
+    // Watch time carried across sessions for the same item, so an item taken up
+    // over several sittings, or a stream that breaks and reconnects, is
+    // measured as one viewing. Persisted, because over a window measured in
+    // days a restart is expected rather than exceptional. See WatchCarryStore.
+    private readonly WatchCarryStore _carried;
+    private string? _reportedCarryError;
 
     public PlaybackCompletionTracker(
+        IApplicationPaths applicationPaths,
         ISessionManager sessionManager,
         ILibraryManager libraryManager,
         IUserDataManager userDataManager,
@@ -64,6 +70,39 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         _userDataManager = userDataManager;
         _playbackCompletionService = playbackCompletionService;
         _logger = logger;
+
+        var days = Plugin.Instance?.Configuration?.WatchCarryRetentionDays ?? 7;
+        _carried = days > 0
+            ? new WatchCarryStore(
+                TimeSpan.FromDays(days),
+                Path.Combine(applicationPaths.PluginConfigurationsPath, "achievementbadges", "watch-carry.json"))
+            : new WatchCarryStore(TimeSpan.Zero);
+    }
+
+    /// <summary>
+    /// Surfaces a carry file that could not be read or written. Reported once
+    /// per distinct error so a failing disk does not flood the log, but never
+    /// swallowed: silence here would mean partial viewings quietly stop being
+    /// carried and nobody finds out until credit goes missing.
+    /// </summary>
+    private void ReportCarryPersistError()
+    {
+        var error = _carried.LastPersistError;
+        if (error is null)
+        {
+            _reportedCarryError = null;
+            return;
+        }
+
+        if (string.Equals(error, _reportedCarryError, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _reportedCarryError = error;
+        _logger.LogWarning(
+            "[AchievementBadges] Could not persist carried watch time ({Error}). Partial viewings will not survive a restart until this is fixed.",
+            error);
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -403,6 +442,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             {
                 // Credited, so a later viewing of the same item starts clean.
                 _carried.Clear(userId, itemId);
+                ReportCarryPersistError();
 
                 _logger.LogInformation(
                     "[AchievementBadges] Recorded playback from {Source} user={UserId} item={ItemId} library={Library} completion={Completion:0.##}%",
@@ -410,10 +450,11 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             }
             else
             {
-                // Not credited: remember what was genuinely watched so a
-                // reconnect can pick up where this session left off instead of
-                // starting from zero.
+                // Not credited: remember what was genuinely watched so the next
+                // sitting picks up where this one left off instead of starting
+                // from zero.
                 _carried.Remember(userId, itemId, accumulatedPlayTicks, now);
+                ReportCarryPersistError();
 
                 _logger.LogDebug(
                     "[AchievementBadges] Skipped playback from {Source} user={UserId} item={ItemId} reason={Reason}",

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Jellyfin.Plugin.AchievementBadges.Models;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -46,6 +47,10 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         public int ProgressEventCount;
     }
     private readonly ConcurrentDictionary<string, SessionWatchState> _sessions = new();
+
+    // Watch time carried across sessions for the same item, so a stream that
+    // breaks and reconnects is measured as one viewing. See WatchCarryStore.
+    private readonly WatchCarryStore _carried = new();
 
     public PlaybackCompletionTracker(
         ISessionManager sessionManager,
@@ -302,6 +307,24 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
                 progressEventCount = session.ProgressEventCount;
             }
 
+            // Fold in anything watched for this item in an earlier session that
+            // ended without credit, so a stream that broke and reconnected is
+            // measured as one viewing. See WatchCarryStore for why this is safe.
+            var now = DateTimeOffset.UtcNow;
+            var carriedTicks = _carried.Peek(userId, itemId, now);
+            if (carriedTicks > 0)
+            {
+                _logger.LogInformation(
+                    "[AchievementBadges] {Source} for user {UserId} item {ItemId}: adding {Carried}s carried from an earlier session of the same item to this session's {Session}s.",
+                    source,
+                    userId,
+                    itemId,
+                    carriedTicks / TimeSpan.TicksPerSecond,
+                    accumulatedPlayTicks / TimeSpan.TicksPerSecond);
+
+                accumulatedPlayTicks += carriedTicks;
+            }
+
             double completionPercent;
             if (runTimeTicks > 0)
             {
@@ -378,12 +401,20 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
 
             if (success)
             {
+                // Credited, so a later viewing of the same item starts clean.
+                _carried.Clear(userId, itemId);
+
                 _logger.LogInformation(
                     "[AchievementBadges] Recorded playback from {Source} user={UserId} item={ItemId} library={Library} completion={Completion:0.##}%",
                     source, userId, itemId, libraryName ?? "(none)", completionPercent);
             }
             else
             {
+                // Not credited: remember what was genuinely watched so a
+                // reconnect can pick up where this session left off instead of
+                // starting from zero.
+                _carried.Remember(userId, itemId, accumulatedPlayTicks, now);
+
                 _logger.LogDebug(
                     "[AchievementBadges] Skipped playback from {Source} user={UserId} item={ItemId} reason={Reason}",
                     source, userId, itemId, message);


### PR DESCRIPTION
Fixes #65.

Stacked on #62, so it contains that commit as well. If #62 is merged first this diff shrinks to the second commit on its own.

#62 carries watch time across a reconnect, a break measured in seconds. This carries it across the way people actually watch a long item: in sittings, spread over a day or several days. Without it, a two hour episode taken in five sittings never has one sitting worth 80% of its runtime, so it never credits no matter how often it is watched to the end.

## What changed

`WatchCarryStore` gains a window measured in days and a file behind it.

- The default window is seven days instead of six hours, configurable through `WatchCarryRetentionDays`. Zero disables carrying entirely.
- The carry is persisted to `watch-carry.json` next to the plugin's other data. Over a span measured in days a restart is expected rather than exceptional, and an in memory carry would hand every partial viewing on the server back to zero on the next restart.
- Writes go to a temporary file and are moved into place, so a shutdown in the middle of a write cannot leave a truncated file to be discarded on the next boot.
- An entry that expired while the server was down is dropped on load rather than resurrected.
- A read or write failure is reported through `LastPersistError` and logged once per distinct error by the tracker, rather than quietly ending the carrying. Losing the carry silently is the same class of failure this store exists to prevent.

`PlaybackCompletionTracker` takes `IApplicationPaths` to place the file and reads the retention setting when it starts.

## What did not change

The anti abuse gate. Only genuinely advanced playback time is ever carried, because seeks are excluded in `UpdateSessionState` before the ticks reach the store. The carry is dropped the moment the item is credited, so a later re watch starts from zero. The 80% threshold in `PlaybackCompletionService` is untouched.

A longer window cannot manufacture watch time that did not happen. It only stops the plugin from throwing away watch time that did.

## Tests

Eight new cases, seven of which fail without this change:

- an 8283s episode across five sittings from 09:47 to 21:01 credits, using the real timings from #65
- the old six hour window explicitly does not, pinning why the default moved
- an item left and resumed days later still credits, and one left past the window does not
- the carry survives a restart
- an entry that expired while the server was down is not resurrected
- a credited item stays cleared across a restart
- an unreadable carry file starts empty instead of throwing, and the next write replaces it
- the retention default is seven days

The persistence cases are anchored to the current time rather than a fixed date, since loading judges expiry against the real clock and a fixed date would eventually fall outside the window and fail on its own.

Full suite passes.
