### PR TITLE
fix: floor the score bank on a watch history rebuild so deleted media cannot zero a balance

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/DataResilienceTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/DataResilienceTests.cs
@@ -203,4 +203,58 @@ public class DataResilienceTests : IDisposable
     {
         Assert.Equal(14, new PluginConfiguration().SnapshotRetentionDays);
     }
+
+    private const string BankUserId = "44444444-4444-4444-4444-444444444444";
+    private const string UnknownUserId = "55555555-5555-5555-5555-555555555555";
+
+    [Fact]
+    public void ScoreBankFloor_EmptyReplay_KeepsTheBalance()
+    {
+        // The reported case. Every item this user watched has since been
+        // deleted, so the replay observes nothing at all and the rebuilt bank
+        // is zero, even though the reset carried all their badges over.
+        var profile = _badges.GetOrCreateProfileDirect(BankUserId);
+        profile.ScoreBank = 15;
+        _badges.SaveProfileDirect(profile);
+
+        var preScan = _badges.SnapshotScoreBankForUser(BankUserId);
+        _badges.ResetBadgesForUser(BankUserId);
+        Assert.Equal(0, _badges.PeekProfile(BankUserId)!.ScoreBank);
+
+        _badges.ApplyScoreBankFloor(BankUserId, preScan);
+
+        Assert.Equal(15, _badges.PeekProfile(BankUserId)!.ScoreBank);
+    }
+
+    [Fact]
+    public void ScoreBankFloor_RicherRebuild_KeepsTheLargerValue()
+    {
+        // The floor must not cap growth: a replay that legitimately earns more
+        // than the user had banked keeps its own result.
+        var profile = _badges.GetOrCreateProfileDirect(BankUserId);
+        profile.ScoreBank = 120;
+        _badges.SaveProfileDirect(profile);
+
+        var preScan = _badges.SnapshotScoreBankForUser(BankUserId);
+
+        var rebuilt = _badges.GetOrCreateProfileDirect(BankUserId);
+        rebuilt.ScoreBank = 5707;
+        _badges.SaveProfileDirect(rebuilt);
+
+        _badges.ApplyScoreBankFloor(BankUserId, preScan);
+
+        Assert.Equal(5707, _badges.PeekProfile(BankUserId)!.ScoreBank);
+    }
+
+    [Fact]
+    public void ScoreBankFloor_UnknownUserOrEmptyBank_IsANoOp()
+    {
+        // A first-ever scan has nothing to floor against, and asking must not
+        // materialise a profile as a side effect.
+        Assert.Equal(0, _badges.SnapshotScoreBankForUser(UnknownUserId));
+
+        _badges.ApplyScoreBankFloor(UnknownUserId, 0);
+
+        Assert.Null(_badges.PeekProfile(UnknownUserId));
+    }
 }

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -1636,6 +1636,53 @@ public class AchievementBadgeService : IDisposable
     }
 
     /// <summary>
+    /// Reads the user's current score bank, or zero when the user has no
+    /// profile yet. Companion to <see cref="SnapshotCountersForUser"/>, taken
+    /// by the backfill right before it resets a profile.
+    /// </summary>
+    public int SnapshotScoreBankForUser(string userId)
+    {
+        userId = NormalizeUserId(userId);
+        lock (_lock)
+        {
+            return _userProfiles.TryGetValue(userId, out var profile) ? profile.ScoreBank : 0;
+        }
+    }
+
+    /// <summary>
+    /// Floors the user's score bank at a snapshot taken before a rebuild.
+    /// <para>
+    /// The bank is not derived from badges, so carrying unlocks over does not
+    /// carry it: it accrues per watched item, which means a rebuild recomputes
+    /// it from whatever playback the replay can still see. Media deleted since
+    /// it was watched is invisible to that replay, so without a floor a scan
+    /// quietly spends the user's balance for them, and a user whose watched
+    /// media is all gone drops to zero while keeping every badge. That is the
+    /// same loss window issue #48 closed for counters.
+    /// </para>
+    /// </summary>
+    public void ApplyScoreBankFloor(string userId, int previousScoreBank)
+    {
+        if (previousScoreBank <= 0)
+        {
+            return;
+        }
+
+        userId = NormalizeUserId(userId);
+        lock (_lock)
+        {
+            if (!_userProfiles.TryGetValue(userId, out var profile)
+                || profile.ScoreBank >= previousScoreBank)
+            {
+                return;
+            }
+
+            profile.ScoreBank = previousScoreBank;
+            Save();
+        }
+    }
+
+    /// <summary>
     /// Carry over everything a watch-history rebuild cannot reconstruct.
     /// <para>
     /// The reset exists so the backfill can recompute counters from playback

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -109,6 +109,11 @@ public class WatchHistoryBackfillService
             // silently shrink.
             var preScanCounters = _achievementBadgeService.SnapshotCountersForUser(userId);
 
+            // Same window, separate value: the score bank is spendable
+            // currency that accrues per watched item, not per badge, so
+            // carrying unlocks over does not carry it.
+            var preScanScoreBank = _achievementBadgeService.SnapshotScoreBankForUser(userId);
+
             // Reset badges so we rebuild from watch history
             _achievementBadgeService.ResetBadgesForUser(userId);
 
@@ -297,6 +302,7 @@ public class WatchHistoryBackfillService
             // Issue #48 companion: floor the rebuilt counters at their
             // pre scan values so deleted media never shrinks lifetime totals.
             _achievementBadgeService.ApplyCounterFloor(userId, preScanCounters);
+            _achievementBadgeService.ApplyScoreBankFloor(userId, preScanScoreBank);
 
             _logger.LogInformation(
                 "[AchievementBadges] Backfill done for {Username}: {Movies} movies, {Episodes} episodes, {Series} series, {Books} books, {Libraries} libraries.",


### PR DESCRIPTION
Closes #67.

The score bank accrues per watched item, not per badge, so carrying unlocks across the reset does not carry it. A user whose watched media has since been deleted replays nothing at all, and the rebuilt bank stays at zero while every badge survives. Measured on a live profile: 15 to 0, with badges and showcase intact.

This mirrors what #57 did for counters. Snapshot the value before the reset, floor the rebuilt value at it, and a scan can then only move the balance forward.

## Changes

- `SnapshotScoreBankForUser` reads the bank before the reset, returning zero for a user who has no profile yet.
- `ApplyScoreBankFloor` raises the rebuilt bank back to that snapshot when the replay produced less. It is a no op for a zero snapshot and for an unknown user, and it deliberately does not create a profile as a side effect of asking.
- The backfill takes the snapshot next to the existing counter snapshot, and applies the floor next to the existing counter floor, so the two loss windows are handled in the same place.

Growth is untouched: a replay that legitimately earns more than the user had banked keeps its own larger result.

## Tests

Three added to `DataResilienceTests`:

- `ScoreBankFloor_EmptyReplay_KeepsTheBalance` reproduces the report. The reset zeroes the bank, the floor puts it back.
- `ScoreBankFloor_RicherRebuild_KeepsTheLargerValue` pins that the floor bounds loss without capping growth.
- `ScoreBankFloor_UnknownUserOrEmptyBank_IsANoOp` covers a first ever scan, where there is nothing to floor against.

I confirmed the first one fails without the change, rather than assuming it would. Full suite is 120/120 and the Release build is clean.

Only additions, no existing behaviour changed. As always, take it or leave it and I am happy to rework anything.
