### PR TITLE
fix: send Cache-Control no-store on the dynamic JSON endpoints

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/ResponseCacheDefaultsTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/ResponseCacheDefaultsTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Reflection;
+using Jellyfin.Plugin.AchievementBadges.Api;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Pins the cache policy of the controllers that return per-user, constantly
+/// changing JSON. Without an explicit directive these responses carry no
+/// freshness information at all, which lets a browser or an intermediary
+/// apply heuristic caching and serve one user's stale profile, friends list
+/// or quest state for an unbounded amount of time.
+/// </summary>
+public class ResponseCacheDefaultsTests
+{
+    [Theory]
+    [InlineData(typeof(AchievementBadgesController))]
+    [InlineData(typeof(CustomBadgesController))]
+    [InlineData(typeof(TimeWindowedAdminController))]
+    public void DynamicControllers_DefaultToNoStore(Type controller)
+    {
+        var attribute = controller.GetCustomAttribute<ResponseCacheAttribute>();
+
+        Assert.NotNull(attribute);
+        Assert.True(attribute!.NoStore);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -23,6 +23,12 @@ namespace Jellyfin.Plugin.AchievementBadges.Api;
 // recompute-cooldown, ip-30-per-min) keep their explicit method-level
 // [EnableRateLimiting] which OVERRIDES this default per ASP.NET semantics.
 [EnableRateLimiting("user-60-per-min")]
+// Dynamic JSON responses ship Cache-Control: no-store so
+// browsers and proxies never serve stale profiles, friends or quests from
+// heuristic caching. The filter writes the header before the action runs,
+// so routes that set an explicit policy in their body (client-script and
+// asset immutable, translations no-cache, attachments private) still win.
+[ResponseCache(NoStore = true)]
 public class AchievementBadgesController : ControllerBase
 {
     private readonly AchievementBadgeService _badgeService;

--- a/Jellyfin.Plugin.AchievementBadges/Api/CustomBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/CustomBadgesController.cs
@@ -21,6 +21,8 @@ namespace Jellyfin.Plugin.AchievementBadges.Api;
 [ApiController]
 [Authorize(Policy = "RequiresElevation")]
 [Route("Plugins/AchievementBadges/custom-badges")]
+// Admin JSON must never be cached (see AchievementBadgesController).
+[ResponseCache(NoStore = true)]
 public class CustomBadgesController : ControllerBase
 {
     private readonly CustomBadgeService _customBadges;

--- a/Jellyfin.Plugin.AchievementBadges/Api/TimeWindowedAdminController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/TimeWindowedAdminController.cs
@@ -16,6 +16,8 @@ namespace Jellyfin.Plugin.AchievementBadges.Api;
 [ApiController]
 [Authorize(Policy = "RequiresElevation")]
 [Route("Plugins/AchievementBadges/time-windowed")]
+// Admin JSON must never be cached (see AchievementBadgesController).
+[ResponseCache(NoStore = true)]
 public class TimeWindowedAdminController : ControllerBase
 {
     private readonly TimeWindowedRecomputeService _recompute;


### PR DESCRIPTION
Closes #69.

The profile, friends, quest and admin JSON responses carry no cache directive at all: no `Cache-Control`, no `ETag`, no `Last-Modified`, no `Expires`. With no freshness information a browser or an intermediary may apply heuristic freshness and reuse the response for an interval it chooses, so a user can keep seeing an old profile or an old friends list while the server has already moved on. It reads like a plugin bug, because curl against the server returns the correct payload the whole time.

## Changes

- `[ResponseCache(NoStore = true)]` on `AchievementBadgesController`, `CustomBadgesController` and `TimeWindowedAdminController`.
- `ResponseCacheDefaultsTests` pins it for all three.

The attribute filter writes the header before the action runs, so routes that set an explicit policy in their own body still win. I checked each of them: the client-script and asset routes keep `immutable`, translations keep `no-cache`, attachments keep `private`.

`StandalonePageController` is deliberately untouched, since it serves pages rather than per-user JSON.

## Verification

I removed the three attributes and confirmed all three test cases fail, rather than assuming they would. Full suite 120/120, Release build 0 warnings. Running in production here since the beginning of August.

Only additions, no existing behaviour changed. As always, take it or leave it and I am happy to rework anything.
