### PR TITLE
fix: hide the floating friends button while the video player is on screen

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Pins the rules that keep the plugin's floating UI off the video player.
+/// The header badge row has been hidden during playback for a long time; the
+/// friends button is position:fixed at the same kind of z-index and needs the
+/// same treatment, or it covers the OSD controls.
+/// </summary>
+public class PlayerOverlayTests
+{
+    private static string ReadEmbedded(string suffix)
+    {
+        var assembly = typeof(Plugin).Assembly;
+        var name = assembly.GetManifestResourceNames().Single(n => n.EndsWith(suffix, StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(name)!;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    [Fact]
+    public void FriendsButton_IsHiddenDuringPlayback_FromTheGloballyInjectedBlock()
+    {
+        // The load bearing copy must be in enhance.js: styles-revamp.css only
+        // loads with the revamp theme on the plugin's own pages, while the
+        // button floats on every page, including over the player.
+        var js = ReadEmbedded("enhance.js");
+
+        Assert.Contains("body:has(.videoPlayerContainer) #abFriendsBtn", js);
+        Assert.Contains("body.videoOsdOpen #abFriendsBtn", js);
+        Assert.Contains(".videoPlayer #abFriendsBtn", js);
+        Assert.Contains("body:has(.mainAnimatedPage.videoOsdPage) #abFriendsBtn { display: none !important; }", js);
+    }
+
+    [Fact]
+    public void FriendsButton_RuleIsUnscoped_SoEveryThemeGetsIt()
+    {
+        var css = ReadEmbedded("styles-revamp.css");
+
+        var start = css.IndexOf("body:has(.videoPlayerContainer) #abFriendsBtn", StringComparison.Ordinal);
+        Assert.True(start >= 0, "the redundant revamp copy of the rule is missing");
+
+        var rule = css.Substring(start);
+        rule = rule.Substring(0, rule.IndexOf('}'));
+        Assert.Contains("display: none !important", rule);
+    }
+
+    [Fact]
+    public void HeaderBadges_KeepTheirExistingPlaybackRules()
+    {
+        // Guards the selector battery the friends button rule was modelled on,
+        // so a future edit cannot quietly drop half of it.
+        var js = ReadEmbedded("enhance.js");
+
+        Assert.Contains("body:has(.videoPlayerContainer) #ab-header-badges", js);
+        Assert.Contains("body.videoOsdOpen #ab-header-badges", js);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
@@ -646,6 +646,22 @@
             'body:has(.videoPlayer) #ab-header-badges,' +
             'body:has(#videoOsdPage) #ab-header-badges,' +
             'body:has(.mainAnimatedPage.videoOsdPage) #ab-header-badges { display: none !important; }' +
+            // The floating friends button gets the same treatment, for the same
+            // reason: it is position:fixed at z-index 9999998, so during
+            // playback it sits on top of the OSD controls. The rule has to live
+            // in THIS globally injected block rather than in styles-revamp.css,
+            // because that sheet only loads with the revamp theme on the
+            // plugin's own pages, while the button is present on every page.
+            '.videoOsdBottom ~ * #abFriendsBtn,' +
+            '.videoPlayer #abFriendsBtn,' +
+            'body.videoPlayerContainerPresent #abFriendsBtn,' +
+            'body.videoOsdOpen #abFriendsBtn,' +
+            'body.osd-open #abFriendsBtn,' +
+            'body:has(.videoPlayerContainer) #abFriendsBtn,' +
+            'body:has(.videoOsdBottom) #abFriendsBtn,' +
+            'body:has(.videoPlayer) #abFriendsBtn,' +
+            'body:has(#videoOsdPage) #abFriendsBtn,' +
+            'body:has(.mainAnimatedPage.videoOsdPage) #abFriendsBtn { display: none !important; }' +
             // Toast container stays visible during playback so unlocks fire mid-watch.
             // Force it above the video OSD layers.
             '#ab-toast-container{z-index:2147483647 !important;}' +

--- a/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
@@ -4212,6 +4212,15 @@ body[data-ab-style="revamp"] #abFriendsBtn:hover {
 body[data-ab-style="revamp"] #abFriendsBtn:active {
     transform: translateY(0);
 }
+
+/* Hide the friends button while the video player is on screen. Deliberately
+   unscoped, unlike the rules around it, so it applies in every theme, and it
+   is a redundant copy of the rule enhance.js injects globally: this sheet only
+   loads on the plugin's pages with the revamp theme, so it cannot be the one
+   that carries the fix. */
+body:has(.videoPlayerContainer) #abFriendsBtn {
+    display: none !important;
+}
 body[data-ab-style="revamp"] #abFriendsBadge {
     background: var(--rv-accent-fr) !important;
     box-shadow: 0 0 0 2px var(--rv-bg-fr) !important;


### PR DESCRIPTION
Closes #71.

The floating friends button is `position: fixed` at `z-index: 9999998` with no rule tying it to playback, so during a video it sits on top of the OSD controls. No preference turns it off: the only friends button setting is which corner it uses, and every corner is inside the player.

`enhance.js` already hides `#ab-header-badges` during playback, using a battery of selectors that covers the several ways Jellyfin signals an open player across versions and themes. This applies the same battery to `#abFriendsBtn`.

## Where the rule lives, and why

In the style block `enhance.js` injects globally, not in `styles-revamp.css`. That sheet only loads with the revamp theme on the plugin's own pages, while the button is present on every page, so a rule that lived only there would leave the button over the player for everyone on classic. I learned that one the hard way. The sheet keeps a redundant unscoped copy for revamp contexts.

## Tests

`PlayerOverlayTests`, three of them:

- the global block carries the friends button selectors
- the revamp sheet's copy is unscoped and sets `display: none`
- the existing header badge rules are still there, so a future edit cannot quietly drop half the battery

I removed the change and confirmed the first two fail, rather than assuming they would. Full suite 120/120, Release build clean.

Only additions, nothing existing changed. Take it or leave it, and happy to rework anything.
