### PR TITLE
fix: move unlock toasts off the subtitle line

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Pins the rules that keep the plugin's floating UI off the video player.
+/// The header badge row has been hidden during playback for a long time; the
+/// friends button is position:fixed at the same kind of z-index and needs the
+/// same treatment, or it covers the OSD controls.
+/// </summary>
+public class PlayerOverlayTests
+{
+    private static string ReadEmbedded(string suffix)
+    {
+        var assembly = typeof(Plugin).Assembly;
+        var name = assembly.GetManifestResourceNames().Single(n => n.EndsWith(suffix, StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(name)!;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    [Fact]
+    public void FriendsButton_IsHiddenDuringPlayback_FromTheGloballyInjectedBlock()
+    {
+        // The load bearing copy must be in enhance.js: styles-revamp.css only
+        // loads with the revamp theme on the plugin's own pages, while the
+        // button floats on every page, including over the player.
+        var js = ReadEmbedded("enhance.js");
+
+        Assert.Contains("body:has(.videoPlayerContainer) #abFriendsBtn", js);
+        Assert.Contains("body.videoOsdOpen #abFriendsBtn", js);
+        Assert.Contains(".videoPlayer #abFriendsBtn", js);
+        Assert.Contains("body:has(.mainAnimatedPage.videoOsdPage) #abFriendsBtn { display: none !important; }", js);
+    }
+
+    [Fact]
+    public void FriendsButton_RuleIsUnscoped_SoEveryThemeGetsIt()
+    {
+        var css = ReadEmbedded("styles-revamp.css");
+
+        var start = css.IndexOf("body:has(.videoPlayerContainer) #abFriendsBtn", StringComparison.Ordinal);
+        Assert.True(start >= 0, "the redundant revamp copy of the rule is missing");
+
+        var rule = css.Substring(start);
+        rule = rule.Substring(0, rule.IndexOf('}'));
+        Assert.Contains("display: none !important", rule);
+    }
+
+    [Fact]
+    public void HeaderBadges_KeepTheirExistingPlaybackRules()
+    {
+        // Guards the selector battery the friends button rule was modelled on,
+        // so a future edit cannot quietly drop half of it.
+        var js = ReadEmbedded("enhance.js");
+
+        Assert.Contains("body:has(.videoPlayerContainer) #ab-header-badges", js);
+        Assert.Contains("body.videoOsdOpen #ab-header-badges", js);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
@@ -50,6 +50,35 @@ public class PlayerOverlayTests
     }
 
     [Fact]
+    public void ToastContainer_Stylesheet_AnchorsTopRight()
+    {
+        // Toasts stay up during playback on purpose, so where they sit matters:
+        // bottom centre is the subtitle line.
+        var css = ReadEmbedded("styles-revamp.css");
+        var block = css.Substring(css.IndexOf("#ab-toast-container {", StringComparison.Ordinal));
+        block = block.Substring(0, block.IndexOf('}'));
+
+        Assert.Contains("top: 4.5em !important", block);
+        Assert.Contains("right: 1.2em !important", block);
+        Assert.Contains("bottom: auto !important", block);
+        Assert.Contains("left: auto !important", block);
+        Assert.Contains("align-items: flex-end !important", block);
+    }
+
+    [Fact]
+    public void ToastContainer_InlineFallback_MatchesTheStylesheet()
+    {
+        // enhance.js builds the container before any sheet is guaranteed to be
+        // loaded, so the inline style has to agree or the first toast of a
+        // session lands on the subtitles anyway.
+        var js = ReadEmbedded("enhance.js");
+
+        Assert.Contains("top:4.5em;right:1.2em", js);
+        Assert.Contains("align-items:flex-end", js);
+        Assert.DoesNotContain("bottom:24px;left:0;right:0", js);
+    }
+
+    [Fact]
     public void HeaderBadges_KeepTheirExistingPlaybackRules()
     {
         // Guards the selector battery the friends button rule was modelled on,

--- a/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
@@ -646,6 +646,22 @@
             'body:has(.videoPlayer) #ab-header-badges,' +
             'body:has(#videoOsdPage) #ab-header-badges,' +
             'body:has(.mainAnimatedPage.videoOsdPage) #ab-header-badges { display: none !important; }' +
+            // The floating friends button gets the same treatment, for the same
+            // reason: it is position:fixed at z-index 9999998, so during
+            // playback it sits on top of the OSD controls. The rule has to live
+            // in THIS globally injected block rather than in styles-revamp.css,
+            // because that sheet only loads with the revamp theme on the
+            // plugin's own pages, while the button is present on every page.
+            '.videoOsdBottom ~ * #abFriendsBtn,' +
+            '.videoPlayer #abFriendsBtn,' +
+            'body.videoPlayerContainerPresent #abFriendsBtn,' +
+            'body.videoOsdOpen #abFriendsBtn,' +
+            'body.osd-open #abFriendsBtn,' +
+            'body:has(.videoPlayerContainer) #abFriendsBtn,' +
+            'body:has(.videoOsdBottom) #abFriendsBtn,' +
+            'body:has(.videoPlayer) #abFriendsBtn,' +
+            'body:has(#videoOsdPage) #abFriendsBtn,' +
+            'body:has(.mainAnimatedPage.videoOsdPage) #abFriendsBtn { display: none !important; }' +
             // Toast container stays visible during playback so unlocks fire mid-watch.
             // Force it above the video OSD layers.
             '#ab-toast-container{z-index:2147483647 !important;}' +

--- a/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
@@ -159,7 +159,12 @@
         if (c) return c;
         c = document.createElement('div');
         c.id = TOAST_ID;
-        c.style.cssText = 'position:fixed;bottom:24px;left:0;right:0;z-index:99999;display:flex;flex-direction:column;align-items:center;gap:14px;pointer-events:none;';
+        // Top right, not bottom centre. Toasts deliberately stay visible during
+        // playback so an unlock lands while you are watching, and bottom centre
+        // is exactly where subtitles are rendered, so a 110px card parked there
+        // for several seconds covers the line being spoken. Kept in sync with
+        // the #ab-toast-container rule in styles-revamp.css.
+        c.style.cssText = 'position:fixed;top:4.5em;right:1.2em;z-index:99999;display:flex;flex-direction:column;align-items:flex-end;gap:14px;pointer-events:none;';
         document.body.appendChild(c);
         return c;
     }

--- a/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
@@ -4212,6 +4212,15 @@ body[data-ab-style="revamp"] #abFriendsBtn:hover {
 body[data-ab-style="revamp"] #abFriendsBtn:active {
     transform: translateY(0);
 }
+
+/* Hide the friends button while the video player is on screen. Deliberately
+   unscoped, unlike the rules around it, so it applies in every theme, and it
+   is a redundant copy of the rule enhance.js injects globally: this sheet only
+   loads on the plugin's pages with the revamp theme, so it cannot be the one
+   that carries the fix. */
+body:has(.videoPlayerContainer) #abFriendsBtn {
+    display: none !important;
+}
 body[data-ab-style="revamp"] #abFriendsBadge {
     background: var(--rv-accent-fr) !important;
     box-shadow: 0 0 0 2px var(--rv-bg-fr) !important;

--- a/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
@@ -1881,13 +1881,18 @@
 
 #ab-toast-container {
     position: fixed !important;
-    bottom: 24px !important;
-    left: 0 !important;
-    right: 0 !important;
+    /* Top right, not bottom centre: toasts stay visible during playback on
+       purpose, and bottom centre is where subtitles are rendered, so a card
+       parked there for several seconds covers the line being spoken. Kept in
+       sync with the inline fallback in enhance.js. */
+    top: 4.5em !important;
+    bottom: auto !important;
+    left: auto !important;
+    right: 1.2em !important;
     z-index: 2147483000 !important;     /* well above any conceivable page chrome */
     display: flex !important;
     flex-direction: column !important;
-    align-items: center !important;
+    align-items: flex-end !important;
     gap: 14px !important;
     pointer-events: none !important;
     /* defeat any inherited transform / will-change / contain that could


### PR DESCRIPTION
Closes #73.

**Stacked on #72.** It touches the same two files, so it includes that commit to stay conflict free. If you merge #72 first this diff shrinks to just the toast commit on its own.

The toast container is anchored bottom centre and stays visible during playback on purpose, so an unlock lands while you are watching. Bottom centre is where the subtitle line is rendered, so the 110px card sits over the line being spoken for the several seconds it is up.

This moves the anchor to the top right. Nothing else changes: toasts still appear during playback, same z-index, same stacking.

## Both copies move together

`enhance.js` builds the container with an inline style before any sheet is guaranteed to have loaded. If only the stylesheet moved, the first toast of a session would still land bottom centre. The tests pin both, and pin that they agree.

## Tests

Added to `PlayerOverlayTests`:

- the stylesheet rule anchors top right and explicitly clears `bottom` and `left`
- the inline fallback in `enhance.js` matches it, and the old `bottom:24px;left:0;right:0` is gone

I removed the change and confirmed both fail. Full suite 122/122, Release build clean.

As I said in the issue, the placement itself is the part I am least attached to. If you would rather have it configurable, anchored elsewhere, or suppressed while subtitles are active, say the word and I will rebuild it that way.
