### PR TITLE
feat: admin-set default achievements UI style, with an option to lock it

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/UiStyleDefaultTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/UiStyleDefaultTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Configuration;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #43: the admin picks the achievements UI style users start on, and
+/// can optionally make it the only one available so the page matches the
+/// server's Jellyfin theme.
+/// </summary>
+public class UiStyleDefaultTests
+{
+    private static string ReadEmbedded(string suffix)
+    {
+        var assembly = typeof(Plugin).Assembly;
+        var name = assembly.GetManifestResourceNames().Single(n => n.EndsWith(suffix, StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(name)!;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    [Fact]
+    public void Defaults_ChangeNothingForExistingServers()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.Equal("classic", config.DefaultUiStyle);
+        Assert.False(config.ForceDefaultUiStyle);
+    }
+
+    [Theory]
+    [InlineData("revamp", "revamp")]
+    [InlineData("Revamp", "revamp")]
+    [InlineData("REVAMP", "revamp")]
+    [InlineData("classic", "classic")]
+    [InlineData("", "classic")]
+    [InlineData("  ", "classic")]
+    [InlineData("nonsense", "classic")]
+    [InlineData(null, "classic")]
+    public void UiStyle_IsNormalisedBeforeItReachesTheClient(string? stored, string expected)
+    {
+        // The setting is a free string in the config file. A hand edited or
+        // misspelt value must not leave the client with a style it cannot
+        // resolve, least of all while the toggle is hidden by the lock.
+        Assert.Equal(expected, UiStyle.Normalize(stored));
+    }
+
+    [Fact]
+    public void Client_ResolvesForcedOverUserChoiceOverAdminDefault()
+    {
+        // Both scripts must agree, since the sidebar decides the style on every
+        // page load while the standalone page owns the toggle.
+        foreach (var script in new[] { "standalone.js", "sidebar.js" })
+        {
+            var js = ReadEmbedded(script);
+            Assert.Contains("ab-style-admin-forced", js);
+            Assert.Contains("ab-style-admin-default", js);
+            Assert.Contains("ab-style-pref", js);
+        }
+    }
+
+    [Fact]
+    public void Client_MirrorsTheAdminSettingsFromPublicConfig()
+    {
+        // sidebar.js reads the mirror synchronously to avoid painting one style
+        // and swapping it, so something has to keep the mirror fresh.
+        var js = ReadEmbedded("standalone.js");
+
+        Assert.Contains("DefaultUiStyle", js);
+        Assert.Contains("ForceDefaultUiStyle", js);
+        Assert.Contains("cacheAdminStyle", js);
+    }
+
+    [Fact]
+    public void Client_GuardsTheToggleItself_NotJustItsVisibility()
+    {
+        // The click handler is wired before public-config has necessarily
+        // landed, and a hidden element is still reachable.
+        var js = ReadEmbedded("standalone.js");
+
+        Assert.Contains("btn.hidden = isStyleForced()", js);
+        Assert.Contains("if (isStyleForced()) { applyStylePref(getStylePref()); return; }", js);
+    }
+
+    [Fact]
+    public void AdminPage_ExposesBothControls()
+    {
+        var html = ReadEmbedded("index.html");
+
+        Assert.Contains("abFcDefaultUiStyle", html);
+        Assert.Contains("abFcForceDefaultUiStyle", html);
+        // Saved as well as loaded: an unwired control silently discards the
+        // admin's choice on every save.
+        Assert.Contains("DefaultUiStyle:", html);
+        Assert.Contains("ForceDefaultUiStyle:", html);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -2383,7 +2383,9 @@ public class AchievementBadgesController : ControllerBase
             FriendsSimpleMode = c?.FriendsSimpleMode ?? false,
             EnableCustomTabsIntegration = c?.EnableCustomTabsIntegration ?? false,
             EnablePluginPagesIntegration = c?.EnablePluginPagesIntegration ?? false,
-            EnableUserMenuShortcut = c?.EnableUserMenuShortcut ?? false
+            EnableUserMenuShortcut = c?.EnableUserMenuShortcut ?? false,
+            DefaultUiStyle = UiStyle.Normalize(c?.DefaultUiStyle),
+            ForceDefaultUiStyle = c?.ForceDefaultUiStyle ?? false
         });
     }
 

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
@@ -143,6 +143,18 @@ public class PluginConfiguration : BasePluginConfiguration
     // "en", "fr", "es", "de", "it", "pt", "zh", "ja".
     public string DefaultLanguage { get; set; } = "en";
 
+    // [issue #43] Default achievements UI style for users who have not used the
+    // Classic/Revamp toggle. "classic" or "revamp"; anything else is treated as
+    // "classic". Mirrors DefaultLanguage above: a starting point, not a lock.
+    public string DefaultUiStyle { get; set; } = "classic";
+
+    // [issue #43] When true, DefaultUiStyle is the only style available: the
+    // Classic/Revamp toggle is hidden and any previous per-user choice is
+    // ignored, so the achievements page can be kept in line with the server's
+    // Jellyfin theme. The user's own choice is remembered, not erased, and
+    // comes back if this is turned off again.
+    public bool ForceDefaultUiStyle { get; set; } = false;
+
     // Admin-supplied SVG used to replace the Xbox logo in the toast animation.
     // Stored as a base64-encoded SVG string (no data:-URI prefix). Empty string
     // means "use the default Xbox logo bundled with the plugin".

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/UiStyle.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/UiStyle.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// The achievements page ships two looks, Classic and Revamp, and the client
+/// only knows those two strings.
+/// <para>
+/// The admin's choice is stored as a free string in the plugin configuration,
+/// so it can arrive empty, misspelt or hand edited. Normalising it in one
+/// place keeps a bad value from reaching the client, which matters most while
+/// <c>ForceDefaultUiStyle</c> is on: the user has no toggle to escape with.
+/// </para>
+/// </summary>
+public static class UiStyle
+{
+    /// <summary>The style used when nothing valid has been configured.</summary>
+    public const string Classic = "classic";
+
+    /// <summary>The alternative look.</summary>
+    public const string Revamp = "revamp";
+
+    /// <summary>
+    /// Collapses any stored value to <see cref="Classic"/> or
+    /// <see cref="Revamp"/>. Comparison is case insensitive and surrounding
+    /// whitespace is ignored; anything unrecognised falls back to Classic,
+    /// which is what the plugin has always defaulted to.
+    /// </summary>
+    public static string Normalize(string? value)
+    {
+        return string.Equals(value?.Trim(), Revamp, StringComparison.OrdinalIgnoreCase)
+            ? Revamp
+            : Classic;
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -1963,6 +1963,16 @@ font-size:0.88em;
                             </select>
                             <div class="secondaryText" style="font-size:0.85em; margin-top:0.25em;" data-i18n="admin.fc.lang_note">Badge titles/descriptions are not yet localized; only UI chrome is translated.</div>
                         </label>
+                        <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.fc.default_ui_style">Default UI style (used when a user hasn't chosen one):</span><br>
+                            <select id="abFcDefaultUiStyle" style="padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
+                                <option value="classic" data-i18n="admin.fc.ui_style_classic">Classic</option>
+                                <option value="revamp" data-i18n="admin.fc.ui_style_revamp">Revamp</option>
+                            </select>
+                        </label>
+                        <label style="display:flex; align-items:center; gap:0.5em; margin-bottom:0.75em;">
+                            <input type="checkbox" id="abFcForceDefaultUiStyle">
+                            <span data-i18n="admin.fc.force_default_ui_style">Only use the default UI style (hides the Classic/Revamp toggle for all users)</span>
+                        </label>
                         <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.fc.audiobook_counting">Audiobook plays count toward:</span><br>
                             <select id="abFcAudiobookCounting" style="padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
                                 <option value="BooksOnly" data-i18n="admin.fc.audiobook_books_only">Books only (default)</option>
@@ -4154,6 +4164,10 @@ font-size:0.88em;
             document.getElementById('abFcWelcomeMessage').value = c.WelcomeMessage || '';
             var dlSel = document.getElementById('abFcDefaultLanguage');
             if (dlSel) dlSel.value = (c.DefaultLanguage || 'en');
+            var uiSel = document.getElementById('abFcDefaultUiStyle');
+            if (uiSel) uiSel.value = (c.DefaultUiStyle === 'revamp' ? 'revamp' : 'classic');
+            var forceUiEl = document.getElementById('abFcForceDefaultUiStyle');
+            if (forceUiEl) forceUiEl.checked = !!c.ForceDefaultUiStyle;
             var abcSel = document.getElementById('abFcAudiobookCounting');
             if (abcSel) abcSel.value = (c.AudiobookCounting || 'BooksOnly');
             var xbEl = document.getElementById('abFcCustomXboxLogoSvg');
@@ -4219,6 +4233,8 @@ font-size:0.88em;
             DisabledBadgeCategories: categories,
             WelcomeMessage: document.getElementById('abFcWelcomeMessage').value || '',
             DefaultLanguage: (document.getElementById('abFcDefaultLanguage') || {}).value || 'en',
+            DefaultUiStyle: (document.getElementById('abFcDefaultUiStyle') || {}).value === 'revamp' ? 'revamp' : 'classic',
+            ForceDefaultUiStyle: !!(document.getElementById('abFcForceDefaultUiStyle') || {}).checked,
             AudiobookCounting: (document.getElementById('abFcAudiobookCounting') || {}).value || 'BooksOnly',
             CustomXboxLogoSvg: (document.getElementById('abFcCustomXboxLogoSvg') || {}).value || '',
             RedactUsernamesInAuditLog: !!(document.getElementById('abFcRedactUsernamesInAuditLog') || {}).checked,

--- a/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
@@ -15,8 +15,20 @@
        double-inject when the user navigates from /achievements to another
        Jellyfin page. */
     try {
+        /* [issue #43] Resolve against the admin's default and lock, which
+           standalone.js mirrors into localStorage whenever public-config
+           lands. This runs on every page load and has to be synchronous, so
+           it reads the mirror instead of fetching: waiting on a round trip
+           here would paint one style and then swap it. */
         var __abPref = null;
-        try { __abPref = localStorage.getItem('ab-style-pref'); } catch (e) {}
+        try {
+            var __abForced = localStorage.getItem('ab-style-admin-forced') === '1';
+            var __abAdmin = localStorage.getItem('ab-style-admin-default') === 'revamp' ? 'revamp' : 'classic';
+            var __abOwn = localStorage.getItem('ab-style-pref');
+            __abPref = __abForced ? __abAdmin
+                : (__abOwn === 'revamp' || __abOwn === 'classic') ? __abOwn
+                : __abAdmin;
+        } catch (e) {}
         if (__abPref === 'revamp') {
             try { document.body.setAttribute('data-ab-style', 'revamp'); } catch (e) {
                 /* body not yet ready — retry once DOM loads */

--- a/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
@@ -4285,9 +4285,42 @@
     var REVAMP_LINK_ID = 'abSaRevampCss';
     // v1.9.0: version-only cache bust (see index.html for full rationale).
     var REVAMP_CSS_BUST = 'v=1.9.2';
-    function getStylePref() {
-        try { return localStorage.getItem(STYLE_PREF_KEY) === 'revamp' ? 'revamp' : 'classic'; }
+    /* [issue #43] The admin's DefaultUiStyle / ForceDefaultUiStyle come from
+       public-config, which is a fetch, but sidebar.js has to pick a style
+       synchronously on every page load or the page flashes the wrong one.
+       So the two values are mirrored into localStorage whenever public-config
+       lands, and both scripts read the mirror. A change by the admin reaches a
+       given browser on its next load, which is the same freshness the language
+       default already has. */
+    var ADMIN_STYLE_KEY = 'ab-style-admin-default';
+    var ADMIN_FORCE_KEY = 'ab-style-admin-forced';
+    function getAdminStyleDefault() {
+        try { return localStorage.getItem(ADMIN_STYLE_KEY) === 'revamp' ? 'revamp' : 'classic'; }
         catch (e) { return 'classic'; }
+    }
+    function isStyleForced() {
+        try { return localStorage.getItem(ADMIN_FORCE_KEY) === '1'; }
+        catch (e) { return false; }
+    }
+    function cacheAdminStyle(cfg) {
+        if (!cfg) return;
+        try {
+            var d = (cfg.DefaultUiStyle || cfg.defaultUiStyle) === 'revamp' ? 'revamp' : 'classic';
+            var f = (cfg.ForceDefaultUiStyle || cfg.forceDefaultUiStyle) ? '1' : '0';
+            localStorage.setItem(ADMIN_STYLE_KEY, d);
+            localStorage.setItem(ADMIN_FORCE_KEY, f);
+        } catch (e) { /* private mode etc. */ }
+    }
+    function getStylePref() {
+        // Forced wins outright. The user's own choice is deliberately left in
+        // place rather than overwritten, so it comes back if the admin turns
+        // the lock off again.
+        if (isStyleForced()) return getAdminStyleDefault();
+        try {
+            var own = localStorage.getItem(STYLE_PREF_KEY);
+            if (own === 'revamp' || own === 'classic') return own;
+        } catch (e) { return 'classic'; }
+        return getAdminStyleDefault();
     }
     function setStylePref(p) {
         try { localStorage.setItem(STYLE_PREF_KEY, p); } catch (e) { /* private mode etc. */ }
@@ -4391,6 +4424,10 @@
         } catch (e) { /* document.body unavailable extremely early — ignore */ }
         var btn = el('abSaStyleToggleBtn');
         if (btn) {
+            // [issue #43] With the admin lock on there is nothing to toggle,
+            // so the control goes away rather than sitting there doing nothing.
+            // Hidden, not disabled: a dead button invites clicking.
+            btn.hidden = isStyleForced();
             // Update the data-i18n key so applyStaticTranslations picks up
             // the correct one on next pass; also set textContent immediately
             // so the user sees the change without waiting for a translations
@@ -4406,6 +4443,9 @@
         if (publicConfigPromise) return publicConfigPromise;
         publicConfigPromise = fetchJson('Plugins/AchievementBadges/public-config').then(function (cfg) {
             publicConfigGlobal = cfg || {};
+            // [issue #43] Refresh the mirror sidebar.js reads synchronously.
+            try { cacheAdminStyle(publicConfigGlobal); } catch (e) {}
+            try { applyStylePref(getStylePref()); } catch (e) {}
             return publicConfigGlobal;
         }).catch(function () {
             publicConfigPromise = null;
@@ -4695,6 +4735,10 @@
         var styleBtn = el('abSaStyleToggleBtn');
         if (styleBtn) {
             styleBtn.addEventListener('click', function () {
+                // [issue #43] Hiding the button is presentation; this is the
+                // actual guard. The handler is wired before public-config has
+                // necessarily landed, and a hidden element is still reachable.
+                if (isStyleForced()) { applyStylePref(getStylePref()); return; }
                 var next = getStylePref() === 'revamp' ? 'classic' : 'revamp';
                 setStylePref(next);
                 applyStylePref(next);


### PR DESCRIPTION
Closes #43.

Both halves of the request: an admin-chosen default UI style, and an option to make it the only one available so the achievements page can be kept in line with the server's Jellyfin theme.

Two settings, `DefaultUiStyle` and `ForceDefaultUiStyle`, defaulting to `classic` and off, so nothing changes for an existing server until an admin opts in.

## Resolution order

`forced ? adminDefault : (user's own choice) : adminDefault`

`DefaultUiStyle` mirrors how `DefaultLanguage` already behaves: a starting point for someone who has not chosen, not a lock. `ForceDefaultUiStyle` is the lock.

A user's own choice is deliberately left in localStorage rather than overwritten while the lock is on, so it comes back if the lock is turned off later.

## Two details that are easy to get wrong

**The toggle is hidden, and the handler guards itself.** Hiding is presentation; the click handler is wired before `public-config` has necessarily landed, and a hidden element is still reachable, so the guard has to be in the handler too. Hidden rather than disabled, because a dead button invites clicking.

**The admin values are mirrored into localStorage.** `sidebar.js` picks a style synchronously on every page load, so it cannot wait on a fetch without painting one style and swapping it. `standalone.js` refreshes the mirror whenever `public-config` lands. The cost is that an admin change reaches a given browser on its next load, which is exactly the freshness the language default already has. If you would rather it were authoritative on the spot, the alternative is putting the two values into the injected bootstrap, and I am happy to redo it that way.

## Normalisation

`Helpers/UiStyle.Normalize` collapses the stored string to `classic` or `revamp`. The setting is a free string in the config file, so it can arrive empty, misspelt or hand edited, and an unrecognised value must not reach the client while the toggle is hidden, since the user would have no way out. Put in `Helpers/` next to `CounterFloor` rather than on the controller.

## Tests

`UiStyleDefaultTests`, thirteen cases:

- defaults change nothing for an existing server
- normalisation over case, whitespace, empty, null and nonsense
- both scripts resolve against the same three keys
- `standalone.js` mirrors the admin settings from `public-config`
- the handler guards the lock, not just the button's visibility
- the admin page both loads and saves the two controls, since an unwired control silently discards the choice on every save

I reverted the client half and confirmed four of them fail, rather than assuming they would. Full suite 130/130, Release build 0 warnings.

Happy to rework any of it, including the placement of the controls on the admin page.
