### PR TITLE
feat: profile card on hover and click in the friends drawer

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/PublicProfileSummaryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/PublicProfileSummaryTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.AchievementBadges.Api;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #42: the friends drawer can show another user's summary card.
+/// These pin the part that matters, which is that it cannot become a way to
+/// see someone who chose not to be seen, or to discover which user ids exist.
+/// </summary>
+public class PublicProfileSummaryTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly AchievementBadgeService _badges;
+
+    private const string Target = "66666666-6666-6666-6666-666666666666";
+
+    public PublicProfileSummaryTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "abprofile_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var paths = new Mock<IApplicationPaths>();
+        paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        _badges = new AchievementBadgeService(
+            paths.Object,
+            new Mock<IUserManager>().Object,
+            new WebhookNotifier(NullLogger<WebhookNotifier>.Instance),
+            new AuditLogService(paths.Object, NullLogger<AuditLogService>.Instance),
+            NullLogger<AchievementBadgeService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private void SeedTarget()
+    {
+        _badges.RecordPlayback(new PlaybackContext
+        {
+            UserId = Target,
+            ItemId = Guid.NewGuid().ToString("D"),
+            IsMovie = true,
+            Silent = true
+        });
+    }
+
+    [Fact]
+    public void UnknownUser_IsIndistinguishableFromAHiddenOne()
+    {
+        // Both answer null, so the endpoint's 404 cannot be used to work out
+        // which user ids exist on the server.
+        Assert.Null(_badges.GetPublicProfileSummary("77777777-7777-7777-7777-777777777777"));
+
+        SeedTarget();
+        var profile = _badges.GetOrCreateProfileDirect(Target);
+        profile.Preferences.HideFromLeaderboard = true;
+        _badges.SaveProfileDirect(profile);
+
+        Assert.Null(_badges.GetPublicProfileSummary(Target));
+    }
+
+    [Fact]
+    public void OptedInUser_ReturnsTheLeaderboardProjection_AndNothingMore()
+    {
+        SeedTarget();
+
+        var summary = _badges.GetPublicProfileSummary(Target);
+        Assert.NotNull(summary);
+
+        // The whole privacy argument rests on this: the card can only ever
+        // show what the leaderboard already publishes. If a field is added
+        // here without being added there, this fails.
+        var expected = new[]
+        {
+            "UserId", "UserName", "Unlocked", "Total", "Percentage",
+            "Score", "BestWatchStreak", "Equipped"
+        };
+        var actual = summary!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
+
+        Assert.Equal(expected.OrderBy(n => n).ToArray(), actual);
+    }
+
+    [Fact]
+    public void HidingFromTheLeaderboardAlsoHidesTheCard()
+    {
+        SeedTarget();
+        Assert.NotNull(_badges.GetPublicProfileSummary(Target));
+
+        var profile = _badges.GetOrCreateProfileDirect(Target);
+        profile.Preferences.HideFromLeaderboard = true;
+        _badges.SaveProfileDirect(profile);
+
+        Assert.Null(_badges.GetPublicProfileSummary(Target));
+    }
+
+    [Fact]
+    public void Route_UsesTargetUserId_SoTheOwnershipFilterDoesNotBlockIt()
+    {
+        // UserOwnershipFilter keys on a route parameter literally named
+        // "userId" and forbids anyone but that user. A summary route named
+        // that way would 403 for every caller, which is exactly the bug this
+        // naming avoids, and it is not obvious from the method alone.
+        var method = typeof(AchievementBadgesController)
+            .GetMethod(nameof(AchievementBadgesController.GetPublicProfileSummary));
+        Assert.NotNull(method);
+
+        var route = method!.GetCustomAttribute<HttpGetAttribute>();
+        Assert.NotNull(route);
+        Assert.Equal("profiles/{targetUserId}/summary", route!.Template);
+        Assert.DoesNotContain("{userId}", route.Template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sidebar_MarksTheHoverTargetsAndCallsTheEndpoint()
+    {
+        var assembly = typeof(Plugin).Assembly;
+        var name = assembly.GetManifestResourceNames().Single(n => n.EndsWith("sidebar.js", StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(name)!;
+        using var reader = new StreamReader(stream);
+        var js = reader.ReadToEnd();
+
+        Assert.Contains("data-ab-profile", js);
+        Assert.Contains("/summary", js);
+        // Keyboard reachable: hover alone would leave the card unreachable
+        // without a pointer.
+        Assert.Contains("tabindex=\\\"0\\\" role=\\\"button\\\"", js.Replace("\"", "\\\""));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -820,6 +820,30 @@ public class AchievementBadgesController : ControllerBase
         return Ok(_badgeService.GetPublicEquippedPreview(targetUserId));
     }
 
+    // [issue #42] Summary card for another user, shown on hover / click in the
+    // friends drawer. Same shape of guard as the equipped preview above:
+    // {targetUserId} so the UserOwnershipFilter ignores it, still requires an
+    // authenticated session, and a malformed id is rejected before any service
+    // work so the lookup cannot act as a timing side-channel for id probing.
+    //
+    // The projection is deliberately the leaderboard's, field for field, and
+    // the service gates on the same ForcePrivacyMode + HideFromLeaderboard
+    // pair, so this reveals nothing that was not already public. A user who
+    // opted out and a user who does not exist both answer 404, so the two
+    // cannot be told apart.
+    [HttpGet("profiles/{targetUserId}/summary")]
+    [EnableRateLimiting("ip-30-per-min")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult GetPublicProfileSummary([FromRoute] string targetUserId)
+    {
+        if (string.IsNullOrWhiteSpace(targetUserId) || targetUserId.Length > 64 || !Guid.TryParse(targetUserId, out _))
+            return NotFound();
+
+        var summary = _badgeService.GetPublicProfileSummary(targetUserId);
+        return summary is null ? NotFound() : Ok(summary);
+    }
+
     [HttpPost("users/{userId}/equipped/{badgeId}")]
     [EnableRateLimiting("user-60-per-min")]
     [ProducesResponseType(typeof(List<AchievementBadge>), StatusCodes.Status200OK)]

--- a/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
@@ -1200,6 +1200,127 @@
             }).catch(function(){});
     }
 
+    /* ===== [issue #42] Profile card for another user =====================
+       Hovering a friend's avatar or name opens a small card; clicking pins it
+       so it survives the pointer leaving, and Escape or a click elsewhere
+       closes it. The card shows exactly what the leaderboard already shows
+       about that user, and the endpoint behind it answers 404 both for
+       someone who has opted out and for an id that does not exist.
+
+       Attached to document rather than to the drawer because the drawer is
+       re-rendered on every friends refresh, which would drop listeners bound
+       to it. */
+    var PROFILE_CARD_ID = 'ab-profile-card';
+    var _profileCache = {};
+    var _profileHoverTimer = null;
+    var _profileCardPinned = false;
+
+    function fetchProfileSummary(userId) {
+        var key = String(userId).toLowerCase();
+        if (_profileCache[key]) return _profileCache[key];
+        _profileCache[key] = fetch(buildUrl('Plugins/AchievementBadges/profiles/' + encodeURIComponent(userId) + '/summary'),
+            { headers: authHeaders(), credentials: 'include' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .catch(function () { return null; });
+        return _profileCache[key];
+    }
+
+    function hideProfileCard() {
+        if (_profileHoverTimer) { clearTimeout(_profileHoverTimer); _profileHoverTimer = null; }
+        _profileCardPinned = false;
+        var c = document.getElementById(PROFILE_CARD_ID);
+        if (c && c.parentNode) c.parentNode.removeChild(c);
+    }
+
+    function renderProfileCard(anchor, data) {
+        hideProfileCard();
+        var card = document.createElement('div');
+        card.id = PROFILE_CARD_ID;
+        card.setAttribute('role', 'dialog');
+        card.style.cssText = 'position:fixed;z-index:9999999;min-width:230px;max-width:290px;' +
+            'padding:0.85em 1em;border-radius:12px;background:rgba(20,20,24,0.97);color:#fff;' +
+            'box-shadow:0 10px 34px rgba(0,0,0,0.55);font-size:0.9em;line-height:1.45;' +
+            'border:1px solid rgba(255,255,255,0.12);pointer-events:auto;';
+
+        // Everything interpolated below is either escaped (the one user
+        // controlled string) or coerced to a number. The counts arrive as
+        // JSON, so their type is not guaranteed by anything on this side.
+        function num(v) { var n = Number(v); return isFinite(n) ? n : 0; }
+        var row = function (label, value) {
+            return '<div style="display:flex;justify-content:space-between;gap:1em;">' +
+                '<span>' + escapeHtml(label) + '</span><strong>' + escapeHtml(value) + '</strong></div>';
+        };
+        card.innerHTML =
+            '<div style="font-weight:600;font-size:1.05em;margin-bottom:0.5em;">' + escapeHtml(data.UserName || '') + '</div>' +
+            row(tr('lb.badges', 'Badges'), num(data.Unlocked) + ' / ' + num(data.Total)) +
+            row(tr('profile.completion', 'Completion'), num(data.Percentage) + '%') +
+            row(tr('lb.score', 'Score'), String(num(data.Score))) +
+            row(tr('lb.streak', 'Best streak'), String(num(data.BestWatchStreak))) +
+            (data.Equipped && data.Equipped.length
+                ? '<div style="margin-top:0.6em;">' + renderEquippedDots(data.Equipped, 20) + '</div>'
+                : '');
+
+        document.body.appendChild(card);
+
+        // Place beside the anchor, then pull back inside the viewport. Fixed
+        // positioning, so no scroll offset maths.
+        var r = anchor.getBoundingClientRect();
+        var cr = card.getBoundingClientRect();
+        var top = Math.max(8, Math.min(r.top, window.innerHeight - cr.height - 8));
+        var left = r.right + 12;
+        if (left + cr.width > window.innerWidth - 8) left = Math.max(8, r.left - cr.width - 12);
+        card.style.top = top + 'px';
+        card.style.left = left + 'px';
+    }
+
+    function openProfileCard(anchor, pin) {
+        var userId = anchor.getAttribute('data-ab-profile');
+        if (!userId) return;
+        fetchProfileSummary(userId).then(function (data) {
+            // 404 means the user opted out of being listed, or does not exist.
+            // Either way there is nothing to show, and nothing to say about
+            // which of the two it was.
+            if (!data) { hideProfileCard(); return; }
+            if (!document.body.contains(anchor)) return;
+            renderProfileCard(anchor, data);
+            _profileCardPinned = !!pin;
+        });
+    }
+
+    document.addEventListener('mouseover', function (ev) {
+        var t = ev.target && ev.target.closest ? ev.target.closest('[data-ab-profile]') : null;
+        if (!t || _profileCardPinned) return;
+        if (_profileHoverTimer) clearTimeout(_profileHoverTimer);
+        // Delay so sweeping the pointer down the list does not fire a request
+        // per row.
+        _profileHoverTimer = setTimeout(function () { openProfileCard(t, false); }, 350);
+    });
+
+    document.addEventListener('mouseout', function (ev) {
+        if (_profileCardPinned) return;
+        var t = ev.target && ev.target.closest ? ev.target.closest('[data-ab-profile]') : null;
+        if (!t) return;
+        var to = ev.relatedTarget;
+        if (to && to.closest && to.closest('#' + PROFILE_CARD_ID)) return;
+        hideProfileCard();
+    });
+
+    document.addEventListener('click', function (ev) {
+        var t = ev.target && ev.target.closest ? ev.target.closest('[data-ab-profile]') : null;
+        if (t) { ev.preventDefault(); openProfileCard(t, true); return; }
+        if (ev.target && ev.target.closest && ev.target.closest('#' + PROFILE_CARD_ID)) return;
+        hideProfileCard();
+    });
+
+    document.addEventListener('keydown', function (ev) {
+        if (ev.key === 'Escape') { hideProfileCard(); return; }
+        if (ev.key !== 'Enter' && ev.key !== ' ') return;
+        var t = ev.target && ev.target.closest ? ev.target.closest('[data-ab-profile]') : null;
+        if (!t) return;
+        ev.preventDefault();
+        openProfileCard(t, true);
+    });
+
     function loadFriends(){
         var uid = getUserId(); if (!uid) return;
         var fBox = document.getElementById('abFriendsPaneFriends');
@@ -1266,10 +1387,15 @@
                             ? ''
                             : '<button type="button" class="ab-fd-act decline" data-ab-friend-remove="' + escapeHtml(f.UserId) + '" title="'+tr('friends.remove','Remove')+'"><span class="material-icons">person_remove</span></button>';
                         var actionsHtml = '<div class="ab-fd-actions">' + chatBtnHtml + removeBtnHtml + '</div>';
+                        // [issue #42] Avatar and name open the profile card.
+                        // Both carry the id so either target works, and the
+                        // name is focusable so the card is reachable without a
+                        // pointer, which hover alone would not be.
+                        var profAttr = ' data-ab-profile="' + escapeHtml(f.UserId) + '"';
                         return '<div class="ab-fd-row">' +
-                            '<div class="ab-fd-avatar'+(f.Online?' online':'')+'" style="' + av + '">' + initialsHtml + '</div>' +
+                            '<div class="ab-fd-avatar'+(f.Online?' online':'')+'" style="' + av + '"' + profAttr + '>' + initialsHtml + '</div>' +
                             '<div class="ab-fd-info">' +
-                                '<div class="ab-fd-name">' + escapeHtml(f.UserName) + '</div>' +
+                                '<div class="ab-fd-name" tabindex="0" role="button"' + profAttr + '>' + escapeHtml(f.UserName) + '</div>' +
                                 '<div class="ab-fd-status'+(f.Online?' online':'')+'">' + status + '</div>' +
                                 (f.Equipped && f.Equipped.length ? '<div style="margin-top:0.35em;">' + renderEquippedDots(f.Equipped, 16) + '</div>' : '') +
                             '</div>' +

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -2484,6 +2484,51 @@ public class AchievementBadgeService : IDisposable
     }
 
     /// <summary>
+    /// [issue #42] Public summary of another user, for the card shown when you
+    /// hover or click a name in the friends drawer.
+    /// <para>
+    /// Projects exactly the fields the leaderboard already publishes to every
+    /// user, and gates on the same two switches: the admin's ForcePrivacyMode
+    /// and the target's own HideFromLeaderboard. So this cannot reveal
+    /// anything that was not already visible, and anyone who opted out of
+    /// being listed stays opted out here too.
+    /// </para>
+    /// <para>
+    /// Returns null both for a user who opted out and for a user who does not
+    /// exist, so a caller cannot tell the two apart and probe for ids.
+    /// </para>
+    /// </summary>
+    public object? GetPublicProfileSummary(string targetUserId)
+    {
+        targetUserId = NormalizeUserId(targetUserId);
+        var config = Plugin.Instance?.Configuration;
+        if (config?.ForcePrivacyMode == true) return null;
+
+        lock (_lock)
+        {
+            if (!_userProfiles.TryGetValue(targetUserId, out var profile)) return null;
+            if (profile.Preferences?.HideFromLeaderboard ?? false) return null;
+
+            EvaluateBadges(profile, targetUserId);
+            var enabled = profile.Badges.Where(b => IsBadgeEnabled(b.Id)).ToList();
+            var unlocked = enabled.Count(b => b.Unlocked);
+            var total = enabled.Count;
+
+            return new
+            {
+                UserId = profile.UserId,
+                UserName = ResolveUserName(profile.UserId),
+                Unlocked = unlocked,
+                Total = total,
+                Percentage = total == 0 ? 0 : Math.Round((double)unlocked / total * 100.0, 1),
+                Score = AchievementScoreHelper.GetTotalUnlockedScore(enabled),
+                BestWatchStreak = profile.Counters.BestWatchStreak,
+                Equipped = BuildEquippedPreview(profile)
+            };
+        }
+    }
+
+    /// <summary>
     /// For each enabled badge id, returns the percentage of users on this
     /// server who have unlocked it. Cached for 5 minutes so the per-badge-
     /// card render on the achievements page doesn't re-scan every profile


### PR DESCRIPTION
Closes #42.

Hovering a friend's avatar or name in the drawer opens a card with their badge count, completion, score, best streak and equipped showcase. Clicking pins it so it survives the pointer leaving; Escape or a click elsewhere closes it. The name is focusable, since hover alone leaves the card unreachable without a pointer.

@TsunamicFlame asked what the point of the profile cards was, so this is the reading I went with: make the card the thing you get when you look at someone in the drawer.

## Privacy, which is most of the thinking here

The card can only show what the leaderboard already publishes. `GetPublicProfileSummary` projects the leaderboard's fields one for one, and gates on the same two switches the leaderboard uses: the admin's `ForcePrivacyMode` and the target's own `HideFromLeaderboard`.

So there is no new exposure: anyone who opted out of being listed is equally invisible here. A test compares the returned property names against that field list, so adding a field here without adding it to the leaderboard fails the build rather than quietly widening what is public.

Two more properties, both copied from the equipped-preview endpoint directly above:

- A user who opted out and an id that does not exist both answer 404, so the endpoint cannot be used to work out which user ids exist.
- Malformed or oversized ids are rejected before any service work, so the dictionary lookup cannot act as a timing side-channel for id probing.

## Route naming

`profiles/{targetUserId}/summary`, not `users/{userId}/summary`. `UserOwnershipFilter` keys on a route parameter literally named `userId` and forbids anyone but that user, so a route named the obvious way would 403 every caller. That is the same reason the equipped preview is named the way it is. A test pins the template, because the reasoning is invisible from the method alone.

## Client details

- Listeners are on `document`, not the drawer: the drawer is rebuilt on every friends refresh and would drop anything bound to it.
- Hover is debounced 350ms, so sweeping the pointer down the list does not fire a request per row.
- Each user's summary is fetched once per session.
- The card is styled inline rather than from `styles-revamp.css`, which only loads with the revamp theme, so classic users get the same card.

## Tests

`PublicProfileSummaryTests`, five of them, covering the indistinguishable 404, the projection matching the leaderboard exactly, the opt-out gate, the route template, and the client markup.

I removed the `HideFromLeaderboard` gate and confirmed two fail, rather than assuming they would. Full suite 122/122, Release build 0 warnings.

The visual design of the card is the part I would most expect you to want changed. Happy to rework it, or to move it behind a setting if you would rather it were opt-in.
