### PR TITLE
feat: credit watch history from Tracearr for what the library scan cannot see

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/TracearrBackfillTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TracearrBackfillTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #45. The value of reading Tracearr is that it holds two things the
+/// library replay structurally cannot: plays of media that has since been
+/// deleted, and how many times an item was played. The danger is counting a
+/// viewing that the replay already counted, which inflates totals in a way
+/// that cannot be undone without the reset that loses everything else.
+/// </summary>
+public class TracearrBackfillTests
+{
+    private static TracearrPlay Play(string ratingKey, string startedAt, bool watched = true)
+        => new()
+        {
+            RatingKey = ratingKey,
+            MediaType = "movie",
+            Watched = watched,
+            StartedAt = DateTimeOffset.Parse(startedAt, System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+    private static HashSet<string> Seen(params string[] ids)
+        => new(ids, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void AnItemTheLibraryAlreadyCredited_ContributesNoSecondFirstWatch()
+    {
+        // The whole no-double-counting rule in one case.
+        var plan = TracearrCreditPlan.Build(
+            new[] { Play("item-a", "2026-01-01T10:00:00Z") },
+            Seen("item-a"));
+
+        Assert.Empty(plan);
+    }
+
+    [Fact]
+    public void RepeatPlaysOfAKnownItem_CountOnlyAsRewatches()
+    {
+        var plan = TracearrCreditPlan.Build(
+            new[]
+            {
+                Play("item-a", "2026-01-01T10:00:00Z"),
+                Play("item-a", "2026-02-01T10:00:00Z"),
+                Play("item-a", "2026-03-01T10:00:00Z")
+            },
+            Seen("item-a"));
+
+        Assert.Equal(2, plan.Count);
+        Assert.All(plan, c => Assert.True(c.IsRewatch));
+    }
+
+    [Fact]
+    public void DeletedMedia_GetsOneRealWatchAndThenRewatches()
+    {
+        // The library cannot prove this item, so its earliest play is a
+        // genuine first watch rather than a repeat.
+        var plan = TracearrCreditPlan.Build(
+            new[]
+            {
+                Play("gone", "2026-03-01T10:00:00Z"),
+                Play("gone", "2026-01-01T10:00:00Z"),
+                Play("gone", "2026-02-01T10:00:00Z")
+            },
+            Seen("something-else"));
+
+        Assert.Equal(3, plan.Count);
+        Assert.False(plan[0].IsRewatch);
+        Assert.True(plan[1].IsRewatch);
+        Assert.True(plan[2].IsRewatch);
+    }
+
+    [Fact]
+    public void TheEarliestPlayIsTheFirstWatch_NotWhicheverArrivedFirst()
+    {
+        // Guards the ordering above: crediting the newest play as the first
+        // watch would date the viewing wrongly and could invent a streak.
+        var plan = TracearrCreditPlan.Build(
+            new[]
+            {
+                Play("gone", "2026-03-01T10:00:00Z"),
+                Play("gone", "2026-01-01T10:00:00Z")
+            },
+            Seen());
+
+        Assert.Equal(
+            DateTimeOffset.Parse("2026-01-01T10:00:00Z", System.Globalization.CultureInfo.InvariantCulture),
+            plan.Single(c => !c.IsRewatch).Play.StartedAt);
+    }
+
+    [Fact]
+    public void UnfinishedPlaysAreIgnored()
+    {
+        // A sample that was abandoned is not a watch, so it must not become
+        // one just because it reached Tracearr.
+        var plan = TracearrCreditPlan.Build(
+            new[]
+            {
+                Play("gone", "2026-01-01T10:00:00Z", watched: false),
+                Play("gone", "2026-02-01T10:00:00Z", watched: false)
+            },
+            Seen());
+
+        Assert.Empty(plan);
+    }
+
+    [Fact]
+    public void NullsAndEmptyKeysAreSurvivable()
+    {
+        Assert.Empty(TracearrCreditPlan.Build(null, Seen()));
+        Assert.Empty(TracearrCreditPlan.Build(new[] { Play("", "2026-01-01T10:00:00Z") }, null));
+    }
+
+    [Theory]
+    [InlineData("http://10.0.0.5:3000", true)]
+    [InlineData("http://192.168.1.10:3000", true)]
+    [InlineData("http://localhost:3000", true)]
+    [InlineData("https://tracearr.example/", true)]
+    [InlineData("tracearr.example", false)]
+    [InlineData("ftp://tracearr.example", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void PrivateAddressesAreAccepted_UnlikeAWebhookTarget(string? url, bool expected)
+    {
+        // Deliberate difference from WebhookUrlValidator, which rejects private
+        // ranges. A self-hosted Tracearr is nearly always on the same LAN as
+        // Jellyfin, often the same host, so rejecting those would reject the
+        // normal case. This value comes from a server admin, not a user.
+        Assert.Equal(expected, TracearrClient.TryBuildBaseUri(url, out _, out _));
+    }
+
+    [Fact]
+    public void TrailingSlashIsTrimmed_SoPathsDoNotDouble()
+    {
+        Assert.True(TracearrClient.TryBuildBaseUri("https://tracearr.example/", out var uri, out _));
+        Assert.Equal("https://tracearr.example/", uri!.ToString());
+        Assert.Equal("https://tracearr.example/api/v2/public/users", new Uri(uri, "/api/v2/public/users").ToString());
+    }
+
+    [Theory]
+    [InlineData("", "", false)]
+    [InlineData("https://tracearr.example", "", false)]
+    [InlineData("", "token", false)]
+    [InlineData("   ", "token", false)]
+    [InlineData("https://tracearr.example", "token", true)]
+    public void BothFieldsAreRequired_AbsenceIsTheOffSwitch(string url, string token, bool expected)
+    {
+        Assert.Equal(expected, TracearrClient.IsConfigured(url, token));
+    }
+
+    [Fact]
+    public void UserIdsMatchAcrossHyphenAndCaseDifferences()
+    {
+        // Jellyfin and Tracearr do not agree on GUID formatting, and a failed
+        // match would silently credit nothing at all.
+        Assert.Equal(
+            TracearrClient.Compact("5DD06EE5-CED1-4CEE-A5E5-CBC29D2425C4"),
+            TracearrClient.Compact("5dd06ee5ced14ceea5e5cbc29d2425c4"));
+    }
+
+    [Fact]
+    public void AdminPage_BothLoadsAndSavesTheTwoFields()
+    {
+        // An unwired control silently discards what the admin typed on every
+        // save, and the failure looks like "the integration does not work".
+        var assembly = typeof(Plugin).Assembly;
+        var name = assembly.GetManifestResourceNames()
+            .Single(n => n.EndsWith("index.html", StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(name)!;
+        using var reader = new System.IO.StreamReader(stream);
+        var html = reader.ReadToEnd();
+
+        Assert.Contains("abFcTracearrUrl", html, StringComparison.Ordinal);
+        Assert.Contains("abFcTracearrApiToken", html, StringComparison.Ordinal);
+        Assert.Contains("TracearrUrl:", html, StringComparison.Ordinal);
+        Assert.Contains("TracearrApiToken:", html, StringComparison.Ordinal);
+        // The token is a credential, so it must not render in clear text.
+        Assert.Contains("id=\"abFcTracearrApiToken\" autocomplete=\"off\"", html, StringComparison.Ordinal);
+        Assert.Contains("type=\"password\" id=\"abFcTracearrApiToken\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlayMapping_ReadsWhatMatters_AndSkipsRowsWithNoItemId()
+    {
+        var row = JsonDocument.Parse("""
+            {
+              "rating_key": "abc123",
+              "media_type": "episode",
+              "media_title": "Night Country: Part 1",
+              "show_title": "True Detective",
+              "year": 2024,
+              "started_at": "2026-01-01T10:00:00Z",
+              "duration_ms": 1500,
+              "total_duration_ms": 3600000,
+              "watched": true,
+              "bitrate": 8000
+            }
+            """).RootElement;
+
+        var play = TracearrClient.MapPlay(row);
+
+        Assert.NotNull(play);
+        Assert.Equal("abc123", play!.RatingKey);
+        Assert.Equal("episode", play.MediaType);
+        Assert.Equal("True Detective", play.ShowTitle);
+        Assert.Equal(2024, play.Year);
+        Assert.Equal(3600000, play.TotalDurationMs);
+        Assert.True(play.Watched);
+
+        // Without an item id a play cannot be matched against the library at
+        // all, so it could only ever be counted twice.
+        Assert.Null(TracearrClient.MapPlay(JsonDocument.Parse("""{"media_type":"movie"}""").RootElement));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TracearrBackfillTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TracearrBackfillTests.cs
@@ -214,6 +214,28 @@ public class TracearrBackfillTests
     }
 
     [Fact]
+    public void Pagination_ReadsTheCursorFromTheMetaEnvelope()
+    {
+        // Regression. Tracearr wraps pages as { data, meta: { nextCursor } }.
+        // Reading only the root found nothing, so the walk stopped after the
+        // first page and a long history came back truncated with no error.
+        // Observed live: a user with 54 completed viewings yielded 15 credits,
+        // which is one default-sized page.
+        var paged = JsonDocument.Parse("""
+            { "data": [], "meta": { "nextCursor": "abc123", "pageSize": 100 } }
+            """).RootElement;
+        Assert.Equal("abc123", TracearrClient.ReadCursor(paged));
+
+        var lastPage = JsonDocument.Parse("""
+            { "data": [], "meta": { "nextCursor": null, "pageSize": 100 } }
+            """).RootElement;
+        Assert.Null(TracearrClient.ReadCursor(lastPage));
+
+        Assert.Null(TracearrClient.ReadCursor(JsonDocument.Parse("""{"data":[]}""").RootElement));
+        Assert.Null(TracearrClient.ReadCursor(JsonDocument.Parse("""[]""").RootElement));
+    }
+
+    [Fact]
     public void AdminPage_BothLoadsAndSavesTheTwoFields()
     {
         // An unwired control silently discards what the admin typed on every

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TracearrBackfillTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TracearrBackfillTests.cs
@@ -166,6 +166,54 @@ public class TracearrBackfillTests
     }
 
     [Fact]
+    public void AccountLookup_ReadsTheRealUsersPayloadShape()
+    {
+        // Regression. The first version looked for a nested array called
+        // "identities". Tracearr calls it "accounts", so nothing ever matched
+        // and every user was reported as having no Tracearr account, which is
+        // indistinguishable from a server where nobody has streamed. Found in
+        // production rather than here, which is why this test now exists.
+        var payload = JsonDocument.Parse("""
+            {
+              "data": [
+                {
+                  "id": "11111111-1111-1111-1111-111111111111",
+                  "username": "someone-else",
+                  "accounts": [
+                    { "server_type": "jellyfin", "external_user_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+                  ]
+                },
+                {
+                  "id": "22222222-2222-2222-2222-222222222222",
+                  "username": "badpixel",
+                  "accounts": [
+                    { "server_type": "jellyfin", "external_user_id": "5dd06ee5ced14ceea5e5cbc29d2425c4" }
+                  ]
+                }
+              ],
+              "next_cursor": null
+            }
+            """).RootElement;
+
+        // Hyphenated on our side, compact on theirs. The match has to survive
+        // that or it silently credits nothing at all.
+        Assert.Equal(
+            "22222222-2222-2222-2222-222222222222",
+            TracearrClient.FindAccountId(payload, "5DD06EE5-CED1-4CEE-A5E5-CBC29D2425C4"));
+
+        Assert.Null(TracearrClient.FindAccountId(payload, "99999999-9999-9999-9999-999999999999"));
+        Assert.Null(TracearrClient.FindAccountId(payload, ""));
+    }
+
+    [Fact]
+    public void AccountLookup_SurvivesAPayloadWithoutTheNestedArray()
+    {
+        var payload = JsonDocument.Parse("""{"data":[{"id":"1","username":"x"}]}""").RootElement;
+
+        Assert.Null(TracearrClient.FindAccountId(payload, "5dd06ee5ced14ceea5e5cbc29d2425c4"));
+    }
+
+    [Fact]
     public void AdminPage_BothLoadsAndSavesTheTwoFields()
     {
         // An unwired control silently discards what the admin typed on every

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -2422,6 +2422,8 @@ public class AchievementBadgesController : ControllerBase
             DisabledBadgeCategories = c?.DisabledBadgeCategories ?? new List<string>(),
             WelcomeMessage = c?.WelcomeMessage ?? "",
             DefaultLanguage = c?.DefaultLanguage ?? "en",
+            TracearrUrl = c?.TracearrUrl ?? "",
+            TracearrApiToken = c?.TracearrApiToken ?? "",
             CustomXboxLogoSvg = c?.CustomXboxLogoSvg ?? "",
             RedactUsernamesInAuditLog = c?.RedactUsernamesInAuditLog ?? false,
             ForceHideEquippedShowcase = c?.ForceHideEquippedShowcase ?? false,
@@ -2450,6 +2452,10 @@ public class AchievementBadgesController : ControllerBase
         public List<string> DisabledBadgeCategories { get; set; } = new();
         public string WelcomeMessage { get; set; } = "";
         public string DefaultLanguage { get; set; } = "en";
+
+        // [issue #45] Empty either field disables the Tracearr pass.
+        public string TracearrUrl { get; set; } = "";
+        public string TracearrApiToken { get; set; } = "";
         public string CustomXboxLogoSvg { get; set; } = "";
         public bool RedactUsernamesInAuditLog { get; set; } = false;
         public bool ForceHideEquippedShowcase { get; set; } = false;
@@ -2486,6 +2492,8 @@ public class AchievementBadgesController : ControllerBase
         var allowedLangs = new HashSet<string> { "en", "fr", "es", "de", "it", "pt", "zh", "ja" };
         if (!allowedLangs.Contains(lang)) lang = "en";
         config.DefaultLanguage = lang;
+        config.TracearrUrl = (request.TracearrUrl ?? "").Trim();
+        config.TracearrApiToken = (request.TracearrApiToken ?? "").Trim();
 
         // [v2.1.0] Audiobook counting policy. Invalid/missing falls back to
         // the current value (no silent reset to default).

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
@@ -143,6 +143,13 @@ public class PluginConfiguration : BasePluginConfiguration
     // "en", "fr", "es", "de", "it", "pt", "zh", "ja".
     public string DefaultLanguage { get; set; } = "en";
 
+    // [issue #45] Base URL of a Tracearr instance, e.g. https://tracearr.example
+    // or http://10.0.0.5:3000. Empty disables the integration entirely.
+    public string TracearrUrl { get; set; } = "";
+
+    // [issue #45] Public API token for that instance, sent as a Bearer token.
+    public string TracearrApiToken { get; set; } = "";
+
     // Admin-supplied SVG used to replace the Xbox logo in the toast animation.
     // Stored as a base64-encoded SVG string (no data:-URI prefix). Empty string
     // means "use the default Xbox logo bundled with the plugin".

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/TracearrCreditPlan.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/TracearrCreditPlan.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Models;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// [issue #45] Decides which of Tracearr's plays a backfill should credit,
+/// and which of those count as rewatches.
+/// <para>
+/// Kept as a pure function on purpose. This is the one place where a mistake
+/// inflates real people's totals rather than merely losing some, and inflated
+/// totals cannot be walked back without the reset that loses everything else.
+/// </para>
+/// </summary>
+public static class TracearrCreditPlan
+{
+    /// <summary>One play to credit, and whether it is a repeat viewing.</summary>
+    public readonly record struct Credit(TracearrPlay Play, bool IsRewatch);
+
+    /// <summary>
+    /// Given every play Tracearr holds for a user, and the item ids the
+    /// library replay already credited, returns what is left to credit.
+    /// <para>
+    /// The rules, and why:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>Only plays Tracearr considers finished count, so a thirty second
+    /// sample does not become a watch.</item>
+    /// <item>An item the library already credited contributes no first watch
+    /// here. That is what stops the two sources counting one viewing twice.
+    /// </item>
+    /// <item>An item the library could not prove has been deleted since it was
+    /// watched, so its earliest play is a genuine first watch.</item>
+    /// <item>Every later play of anything is a rewatch. The library query is
+    /// <c>IsPlayed = true</c>, a boolean, so it can never produce a rewatch
+    /// count however many times an item was played.</item>
+    /// </list>
+    /// </summary>
+    public static List<Credit> Build(IEnumerable<TracearrPlay>? plays, ISet<string>? alreadyCredited)
+    {
+        var result = new List<Credit>();
+        if (plays is null) return result;
+
+        var seen = alreadyCredited ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var groups = plays
+            .Where(p => p is not null && p.Watched && !string.IsNullOrWhiteSpace(p.RatingKey))
+            .GroupBy(p => p.RatingKey!, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in groups)
+        {
+            var libraryAlreadyCreditedIt = seen.Contains(group.Key);
+
+            // Oldest first, so the earliest viewing is the one that counts as
+            // the first watch and the later ones as repeats, rather than the
+            // order the API happened to return them in.
+            var ordered = group
+                .OrderBy(p => p.StartedAt ?? DateTimeOffset.MinValue)
+                .ToList();
+
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                if (libraryAlreadyCreditedIt && i == 0) continue;
+                result.Add(new Credit(ordered[i], libraryAlreadyCreditedIt || i > 0));
+            }
+        }
+
+        return result;
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Models/TracearrPlay.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/TracearrPlay.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Jellyfin.Plugin.AchievementBadges.Models;
+
+/// <summary>
+/// [issue #45] One play from Tracearr's history, reduced to the fields this
+/// plugin can act on. Tracearr's payload is much wider (codecs, bitrates,
+/// devices, geo); none of that feeds a badge, so it is not carried here.
+/// </summary>
+public class TracearrPlay
+{
+    /// <summary>
+    /// The media server's own item id, Tracearr's <c>rating_key</c>. For a
+    /// Jellyfin server this is the item GUID, which is what lets a play be
+    /// matched against what the library replay already credited.
+    /// </summary>
+    public string? RatingKey { get; set; }
+
+    /// <summary>movie, episode, track, live, photo or unknown.</summary>
+    public string? MediaType { get; set; }
+
+    public string? MediaTitle { get; set; }
+
+    public string? ShowTitle { get; set; }
+
+    public int? Year { get; set; }
+
+    /// <summary>When the play started. Used as the credit date, so a play from
+    /// last year lands on last year rather than today.</summary>
+    public DateTimeOffset? StartedAt { get; set; }
+
+    /// <summary>Time actually watched, not the item's runtime.</summary>
+    public long? DurationMs { get; set; }
+
+    /// <summary>The item's full runtime, when Tracearr knows it.</summary>
+    public long? TotalDurationMs { get; set; }
+
+    /// <summary>Tracearr's own judgement that the item was finished.</summary>
+    public bool Watched { get; set; }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -1963,6 +1963,13 @@ font-size:0.88em;
                             </select>
                             <div class="secondaryText" style="font-size:0.85em; margin-top:0.25em;" data-i18n="admin.fc.lang_note">Badge titles/descriptions are not yet localized; only UI chrome is translated.</div>
                         </label>
+                        <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.fc.tracearr_url">Tracearr URL (optional):</span><br>
+                            <input type="text" id="abFcTracearrUrl" placeholder="https://tracearr.example" style="width:100%; padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
+                        </label>
+                        <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.fc.tracearr_token">Tracearr API token:</span><br>
+                            <input type="password" id="abFcTracearrApiToken" autocomplete="off" style="width:100%; padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
+                            <div class="secondaryText" style="font-size:0.85em; margin-top:0.25em;" data-i18n="admin.fc.tracearr_note">With both filled in, a watch history scan also credits plays Tracearr recorded for media that has since been deleted, plus rewatches, which the library scan cannot see. Generate the token in Tracearr under Settings. Leave either field empty to disable.</div>
+                        </label>
                         <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.fc.audiobook_counting">Audiobook plays count toward:</span><br>
                             <select id="abFcAudiobookCounting" style="padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
                                 <option value="BooksOnly" data-i18n="admin.fc.audiobook_books_only">Books only (default)</option>
@@ -4154,6 +4161,10 @@ font-size:0.88em;
             document.getElementById('abFcWelcomeMessage').value = c.WelcomeMessage || '';
             var dlSel = document.getElementById('abFcDefaultLanguage');
             if (dlSel) dlSel.value = (c.DefaultLanguage || 'en');
+            var tuEl = document.getElementById('abFcTracearrUrl');
+            if (tuEl) tuEl.value = c.TracearrUrl || '';
+            var ttEl = document.getElementById('abFcTracearrApiToken');
+            if (ttEl) ttEl.value = c.TracearrApiToken || '';
             var abcSel = document.getElementById('abFcAudiobookCounting');
             if (abcSel) abcSel.value = (c.AudiobookCounting || 'BooksOnly');
             var xbEl = document.getElementById('abFcCustomXboxLogoSvg');
@@ -4219,6 +4230,8 @@ font-size:0.88em;
             DisabledBadgeCategories: categories,
             WelcomeMessage: document.getElementById('abFcWelcomeMessage').value || '',
             DefaultLanguage: (document.getElementById('abFcDefaultLanguage') || {}).value || 'en',
+            TracearrUrl: (document.getElementById('abFcTracearrUrl') || {}).value || '',
+            TracearrApiToken: (document.getElementById('abFcTracearrApiToken') || {}).value || '',
             AudiobookCounting: (document.getElementById('abFcAudiobookCounting') || {}).value || 'BooksOnly',
             CustomXboxLogoSvg: (document.getElementById('abFcCustomXboxLogoSvg') || {}).value || '',
             RedactUsernamesInAuditLog: !!(document.getElementById('abFcRedactUsernamesInAuditLog') || {}).checked,

--- a/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AchievementBadges.Services;
+
+/// <summary>
+/// [issue #45] Reads watch history from a Tracearr instance over its public v2
+/// API.
+/// <para>
+/// Tracearr records a play when it happens and keeps it afterwards, so it
+/// knows two things the library replay structurally cannot: plays of media
+/// that has since been deleted, and how many times an item was played. The
+/// library query behind the existing backfill is <c>IsPlayed = true</c>, a
+/// boolean over items that still exist.
+/// </para>
+/// </summary>
+public class TracearrClient
+{
+    // Redirects off, like WebhookNotifier: a redirect could otherwise walk an
+    // admin-configured host into somewhere they did not intend.
+    private static readonly HttpClient _http = new(new HttpClientHandler
+    {
+        AllowAutoRedirect = false
+    })
+    { Timeout = TimeSpan.FromSeconds(30) };
+
+    private const int PageSize = 200;
+
+    // A stop, not a target: a server with years of history should not be able
+    // to hold a backfill open indefinitely.
+    private const int MaxPages = 200;
+
+    private readonly ILogger _logger;
+
+    public TracearrClient(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// True when an admin has filled in both fields. Absence is the off
+    /// switch; there is no separate enable flag to fall out of sync with it.
+    /// </summary>
+    public static bool IsConfigured(string? url, string? token)
+    {
+        return !string.IsNullOrWhiteSpace(url) && !string.IsNullOrWhiteSpace(token);
+    }
+
+    /// <summary>
+    /// Validates and normalises the configured base URL.
+    /// <para>
+    /// Deliberately does NOT reuse <c>WebhookUrlValidator</c>. That one
+    /// rejects private address ranges, which is right for a webhook target
+    /// supplied to reach the outside world, and wrong here: a self-hosted
+    /// Tracearr almost always sits on the same LAN as Jellyfin, often on the
+    /// same host. Refusing private ranges would reject the normal case.
+    /// The value is set by a server admin in the plugin configuration, not by
+    /// a user, so the exposure is different in kind.
+    /// </para>
+    /// </summary>
+    public static bool TryBuildBaseUri(string? url, out Uri? baseUri, out string error)
+    {
+        baseUri = null;
+        error = "";
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            error = "Tracearr URL is empty.";
+            return false;
+        }
+
+        if (!Uri.TryCreate(url.Trim().TrimEnd('/'), UriKind.Absolute, out var parsed))
+        {
+            error = "Tracearr URL must be absolute, for example https://tracearr.example.";
+            return false;
+        }
+
+        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+        {
+            error = "Tracearr URL must be http or https.";
+            return false;
+        }
+
+        baseUri = parsed;
+        return true;
+    }
+
+    private static HttpRequestMessage Request(Uri baseUri, string token, string pathAndQuery)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(baseUri, pathAndQuery));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return request;
+    }
+
+    /// <summary>
+    /// Finds the Tracearr account whose linked media-server identity matches
+    /// this Jellyfin user, comparing ids with hyphens stripped because the two
+    /// systems do not agree on GUID formatting.
+    /// </summary>
+    public async Task<string?> ResolveAccountIdAsync(Uri baseUri, string token, string jellyfinUserId, CancellationToken ct)
+    {
+        var wanted = Compact(jellyfinUserId);
+        if (wanted.Length == 0) return null;
+
+        using var response = await _http.SendAsync(Request(baseUri, token, "/api/v2/public/users?page_size=500"), ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("[AchievementBadges] Tracearr /users returned {Status}.", (int)response.StatusCode);
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
+        foreach (var account in EnumerateData(document.RootElement))
+        {
+            if (!account.TryGetProperty("identities", out var identities) || identities.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var identity in identities.EnumerateArray())
+            {
+                var external = ReadString(identity, "external_user_id");
+                if (external is null || Compact(external) != wanted) continue;
+
+                return ReadString(account, "id");
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Every play Tracearr holds for that account, following the cursor to the
+    /// end. Returns what it managed to read: a partial history still closes
+    /// part of the gap, and failing the whole backfill over one bad page would
+    /// be worse than crediting less.
+    /// </summary>
+    public async Task<List<TracearrPlay>> GetHistoryAsync(Uri baseUri, string token, string accountId, CancellationToken ct)
+    {
+        var plays = new List<TracearrPlay>();
+        string? cursor = null;
+
+        for (var page = 0; page < MaxPages; page++)
+        {
+            var path = "/api/v2/public/users/" + Uri.EscapeDataString(accountId)
+                + "/history?page_size=" + PageSize.ToString(CultureInfo.InvariantCulture)
+                + (cursor is null ? "" : "&cursor=" + Uri.EscapeDataString(cursor));
+
+            HttpResponseMessage response;
+            try
+            {
+                response = await _http.SendAsync(Request(baseUri, token, path), ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+            {
+                _logger.LogWarning(ex, "[AchievementBadges] Tracearr history request failed after {Count} plays.", plays.Count);
+                return plays;
+            }
+
+            using (response)
+            {
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning(
+                        "[AchievementBadges] Tracearr history returned {Status} after {Count} plays.",
+                        (int)response.StatusCode, plays.Count);
+                    return plays;
+                }
+
+                using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
+                var before = plays.Count;
+
+                foreach (var row in EnumerateData(document.RootElement))
+                {
+                    var play = MapPlay(row);
+                    if (play is not null) plays.Add(play);
+                }
+
+                cursor = ReadCursor(document.RootElement);
+                // No cursor, or a page that produced nothing: stop rather than
+                // trust the server to terminate the walk for us.
+                if (cursor is null || plays.Count == before) break;
+            }
+        }
+
+        return plays;
+    }
+
+    internal static TracearrPlay? MapPlay(JsonElement row)
+    {
+        var ratingKey = ReadString(row, "rating_key");
+        if (string.IsNullOrWhiteSpace(ratingKey)) return null;
+
+        return new TracearrPlay
+        {
+            RatingKey = ratingKey,
+            MediaType = ReadString(row, "media_type"),
+            MediaTitle = ReadString(row, "media_title"),
+            ShowTitle = ReadString(row, "show_title"),
+            Year = ReadInt(row, "year"),
+            StartedAt = ReadDate(row, "started_at"),
+            DurationMs = ReadLong(row, "duration_ms"),
+            TotalDurationMs = ReadLong(row, "total_duration_ms"),
+            Watched = row.TryGetProperty("watched", out var w) && w.ValueKind == JsonValueKind.True
+        };
+    }
+
+    private static IEnumerable<JsonElement> EnumerateData(JsonElement root)
+    {
+        // Tracearr wraps list responses in { data: [...], next_cursor }, but a
+        // bare array is cheap to tolerate and keeps this from breaking on a
+        // shape change that does not matter here.
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in root.EnumerateArray()) yield return item;
+            yield break;
+        }
+
+        if (root.ValueKind == JsonValueKind.Object
+            && root.TryGetProperty("data", out var data)
+            && data.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in data.EnumerateArray()) yield return item;
+        }
+    }
+
+    private static string? ReadCursor(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object) return null;
+        foreach (var name in new[] { "next_cursor", "nextCursor" })
+        {
+            if (root.TryGetProperty(name, out var c) && c.ValueKind == JsonValueKind.String)
+            {
+                var value = c.GetString();
+                if (!string.IsNullOrWhiteSpace(value)) return value;
+            }
+        }
+        return null;
+    }
+
+    private static string? ReadString(JsonElement row, string name)
+        => row.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static int? ReadInt(JsonElement row, string name)
+        => row.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var i) ? i : null;
+
+    private static long? ReadLong(JsonElement row, string name)
+        => row.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var l) ? l : null;
+
+    private static DateTimeOffset? ReadDate(JsonElement row, string name)
+    {
+        var raw = ReadString(row, name);
+        return DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    internal static string Compact(string? id)
+        => string.IsNullOrWhiteSpace(id) ? "" : id.Replace("-", "", StringComparison.Ordinal).ToLowerInvariant();
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
@@ -119,16 +119,35 @@ public class TracearrClient
         }
 
         using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
-        foreach (var account in EnumerateData(document.RootElement))
+        return FindAccountId(document.RootElement, jellyfinUserId);
+    }
+
+    /// <summary>
+    /// Picks the Tracearr account id whose linked media-server account carries
+    /// this Jellyfin user id.
+    /// <para>
+    /// Split out from the request so the payload shape is covered by a test.
+    /// The first version of this looked for a nested array named "identities",
+    /// which does not exist: Tracearr calls it "accounts", and the mismatch
+    /// failed silently as "no account matches" for every single user, which is
+    /// indistinguishable from a server where nobody has streamed.
+    /// </para>
+    /// </summary>
+    public static string? FindAccountId(JsonElement usersPayload, string jellyfinUserId)
+    {
+        var wanted = Compact(jellyfinUserId);
+        if (wanted.Length == 0) return null;
+
+        foreach (var account in EnumerateData(usersPayload))
         {
-            if (!account.TryGetProperty("identities", out var identities) || identities.ValueKind != JsonValueKind.Array)
+            if (!account.TryGetProperty("accounts", out var linked) || linked.ValueKind != JsonValueKind.Array)
             {
                 continue;
             }
 
-            foreach (var identity in identities.EnumerateArray())
+            foreach (var link in linked.EnumerateArray())
             {
-                var external = ReadString(identity, "external_user_id");
+                var external = ReadString(link, "external_user_id");
                 if (external is null || Compact(external) != wanted) continue;
 
                 return ReadString(account, "id");

--- a/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
@@ -195,7 +195,8 @@ public class TracearrClient
         return plays;
     }
 
-    internal static TracearrPlay? MapPlay(JsonElement row)
+    /// <summary>Public so the mapping can be tested without a live server.</summary>
+    public static TracearrPlay? MapPlay(JsonElement row)
     {
         var ratingKey = ReadString(row, "rating_key");
         if (string.IsNullOrWhiteSpace(ratingKey)) return null;
@@ -264,6 +265,7 @@ public class TracearrClient
             : null;
     }
 
-    internal static string Compact(string? id)
+    /// <summary>Public so the id matching can be tested directly.</summary>
+    public static string Compact(string? id)
         => string.IsNullOrWhiteSpace(id) ? "" : id.Replace("-", "", StringComparison.Ordinal).ToLowerInvariant();
 }

--- a/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
@@ -32,7 +32,10 @@ public class TracearrClient
     })
     { Timeout = TimeSpan.FromSeconds(30) };
 
-    private const int PageSize = 200;
+    // Tracearr caps pageSize at 100 and reads it as camelCase. A snake_case
+    // key is silently ignored, which drops the request to the default of 25
+    // and makes a large history look small.
+    private const int PageSize = 100;
 
     // A stop, not a target: a server with years of history should not be able
     // to hold a backfill open indefinitely.
@@ -111,7 +114,7 @@ public class TracearrClient
         var wanted = Compact(jellyfinUserId);
         if (wanted.Length == 0) return null;
 
-        using var response = await _http.SendAsync(Request(baseUri, token, "/api/v2/public/users?page_size=500"), ct).ConfigureAwait(false);
+        using var response = await _http.SendAsync(Request(baseUri, token, "/api/v2/public/users?pageSize=100"), ct).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogWarning("[AchievementBadges] Tracearr /users returned {Status}.", (int)response.StatusCode);
@@ -171,7 +174,7 @@ public class TracearrClient
         for (var page = 0; page < MaxPages; page++)
         {
             var path = "/api/v2/public/users/" + Uri.EscapeDataString(accountId)
-                + "/history?page_size=" + PageSize.ToString(CultureInfo.InvariantCulture)
+                + "/history?pageSize=" + PageSize.ToString(CultureInfo.InvariantCulture)
                 + (cursor is null ? "" : "&cursor=" + Uri.EscapeDataString(cursor));
 
             HttpResponseMessage response;
@@ -253,17 +256,32 @@ public class TracearrClient
         }
     }
 
-    private static string? ReadCursor(JsonElement root)
+    /// <summary>
+    /// Pulls the next-page cursor out of a paged response.
+    /// <para>
+    /// Tracearr wraps pages as <c>{ data, meta: { nextCursor } }</c>, so the
+    /// cursor is one level down. Reading only the root found nothing, the walk
+    /// stopped after the first page, and a long history came back truncated
+    /// with no error to notice.
+    /// </para>
+    /// </summary>
+    public static string? ReadCursor(JsonElement root)
     {
         if (root.ValueKind != JsonValueKind.Object) return null;
-        foreach (var name in new[] { "next_cursor", "nextCursor" })
+
+        foreach (var container in new[] { root.TryGetProperty("meta", out var meta) ? meta : default, root })
         {
-            if (root.TryGetProperty(name, out var c) && c.ValueKind == JsonValueKind.String)
+            if (container.ValueKind != JsonValueKind.Object) continue;
+            foreach (var name in new[] { "nextCursor", "next_cursor" })
             {
-                var value = c.GetString();
-                if (!string.IsNullOrWhiteSpace(value)) return value;
+                if (container.TryGetProperty(name, out var c) && c.ValueKind == JsonValueKind.String)
+                {
+                    var value = c.GetString();
+                    if (!string.IsNullOrWhiteSpace(value)) return value;
+                }
             }
         }
+
         return null;
     }
 

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Jellyfin.Plugin.AchievementBadges.Models;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -83,6 +85,95 @@ public class WatchHistoryBackfillService
         }
     }
 
+    /// <summary>
+    /// [issue #45] Credits the plays Tracearr holds that the library replay
+    /// could not account for.
+    /// <para>
+    /// Two distinct gaps, and this closes both without overlapping the replay:
+    /// an item Tracearr knows but the library cannot prove is media that has
+    /// been deleted, so its first play is a genuine watch; and every play
+    /// after the first, for any item, is a rewatch. The library query is
+    /// <c>IsPlayed = true</c>, a boolean, so it can never produce a rewatch
+    /// count no matter how many times something was played.
+    /// </para>
+    /// <para>
+    /// Only plays Tracearr itself considers finished are credited, so a
+    /// thirty second sample does not become a watch. Everything is silent:
+    /// a rebuild must not fire a burst of notifications.
+    /// </para>
+    /// </summary>
+    private int RunTracearrPass(string userId, string username, HashSet<string> creditedItemIds)
+    {
+        var config = Plugin.Instance?.Configuration;
+        if (!TracearrClient.IsConfigured(config?.TracearrUrl, config?.TracearrApiToken))
+        {
+            return 0;
+        }
+
+        if (!TracearrClient.TryBuildBaseUri(config!.TracearrUrl, out var baseUri, out var urlError))
+        {
+            _logger.LogWarning("[AchievementBadges] Tracearr not used for {Username}: {Error}", username, urlError);
+            return 0;
+        }
+
+        var credited = 0;
+
+        try
+        {
+            var client = new TracearrClient(_logger);
+            var accountId = client
+                .ResolveAccountIdAsync(baseUri!, config.TracearrApiToken, userId, CancellationToken.None)
+                .GetAwaiter().GetResult();
+
+            if (string.IsNullOrEmpty(accountId))
+            {
+                // Not an error: plenty of Jellyfin users have never streamed
+                // while Tracearr was watching, so they have no account there.
+                _logger.LogInformation("[AchievementBadges] No Tracearr account matches {Username}.", username);
+                return 0;
+            }
+
+            var plays = client
+                .GetHistoryAsync(baseUri!, config.TracearrApiToken, accountId!, CancellationToken.None)
+                .GetAwaiter().GetResult();
+
+            foreach (var credit in TracearrCreditPlan.Build(plays, creditedItemIds))
+            {
+                var play = credit.Play;
+                _achievementBadgeService.RecordPlayback(new PlaybackContext
+                {
+                    UserId = userId,
+                    ItemId = play.RatingKey,
+                    IsMovie = string.Equals(play.MediaType, "movie", StringComparison.OrdinalIgnoreCase),
+                    IsEpisode = string.Equals(play.MediaType, "episode", StringComparison.OrdinalIgnoreCase),
+                    IsRewatch = credit.IsRewatch,
+                    // The date the play happened, not today, so an old viewing
+                    // lands in the right day bucket and cannot manufacture a
+                    // streak that never existed.
+                    PlayedAt = play.StartedAt,
+                    ProductionYear = play.Year,
+                    RunTimeTicks = play.TotalDurationMs is long ms && ms > 0 ? ms * TimeSpan.TicksPerMillisecond : null,
+                    Silent = true
+                });
+
+                credited++;
+            }
+
+            _logger.LogInformation(
+                "[AchievementBadges] Tracearr credited {Count} plays for {Username} that the library could not account for.",
+                credited, username);
+        }
+        catch (Exception ex)
+        {
+            // A backfill that credited the library correctly is still worth
+            // keeping, so a Tracearr failure is reported and swallowed rather
+            // than losing the whole rebuild.
+            _logger.LogWarning(ex, "[AchievementBadges] Tracearr pass failed for {Username}; the library rebuild stands.", username);
+        }
+
+        return credited;
+    }
+
     private object RunBackfillForUserCore(Guid userGuid, string username)
     {
         var userId = userGuid.ToString("D");
@@ -91,6 +182,10 @@ public class WatchHistoryBackfillService
         var seriesCompleted = 0;
         var booksCompleted = 0;
         var librariesFound = new HashSet<string>();
+        // [issue #45] Ids the library replay could prove. Anything Tracearr
+        // knows that is NOT in here is a play of media that has since been
+        // deleted, which is precisely what the library query cannot see.
+        var creditedItemIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         try
         {
@@ -136,6 +231,8 @@ public class WatchHistoryBackfillService
 
                 var (moviesDirectors, moviesActors) = GetPeople(movie);
 
+                creditedItemIds.Add(movie.Id.ToString("D"));
+
                 _achievementBadgeService.RecordPlayback(new PlaybackContext
                 {
                     UserId = userId,
@@ -180,6 +277,8 @@ public class WatchHistoryBackfillService
                     librariesFound.Add(bookLibrary);
                 }
 
+                creditedItemIds.Add(book.Id.ToString("D"));
+
                 _achievementBadgeService.RecordPlayback(new PlaybackContext
                 {
                     UserId = userId,
@@ -220,6 +319,8 @@ public class WatchHistoryBackfillService
                 var playedDate = GetPlayedDate(user, episode);
 
                 var (epDirectors, epActors) = GetPeople(episode);
+
+                creditedItemIds.Add(episode.Id.ToString("D"));
 
                 _achievementBadgeService.RecordPlayback(new PlaybackContext
                 {
@@ -293,6 +394,17 @@ public class WatchHistoryBackfillService
                     _logger.LogWarning(ex, "[AchievementBadges] Failed to check series completion for series {SeriesId}.", seriesId);
                 }
             }
+
+            // [issue #45] Tracearr fills the two holes the replay above cannot
+            // reach: plays of media deleted since it was watched, and how many
+            // times an item was played. No-op unless an admin configured it.
+            //
+            // ORDER MATTERS: this runs BEFORE the counter floor, not after.
+            // The floor restores each counter to its pre scan value, which
+            // already includes those deleted-media watches from back when they
+            // happened. Crediting them after the floor would stack them on top
+            // of themselves and inflate every total they feed.
+            var tracearrCredited = RunTracearrPass(userId, username, creditedItemIds);
 
             // Issue #48 companion: floor the rebuilt counters at their
             // pre scan values so deleted media never shrinks lifetime totals.


### PR DESCRIPTION
Closes #45.

@saranate19 asked for this and @connorgallopo offered help above, so to be clear up front: **nothing is required on the Tracearr side.** This uses its existing public v2 API, and the token is generated in Tracearr's own settings. No change, no coordination, no new endpoint.

## Why it is worth reading Tracearr at all

A watch history scan replays what the library holds: `IsPlayed = true` over items that still exist. That leaves two holes it cannot reach by construction.

**Deleted media is invisible.** An item watched and later removed cannot be replayed, so the credit for it is simply gone. That is the same wound as #48.

**`IsPlayed` is a boolean.** However many times an item was played, the library can only ever say yes or no, so a scan can never produce a rewatch count. `RewatchCount` drives six badges (`rewatcher`, `serial_rewatcher`, `hidden_obsessed`, `rewatch_serial`, `rewatch_comfort`) and a daily quest, and they are unreachable today for anyone who installed the plugin after they had already been watching.

Tracearr records a play when it happens and keeps the row afterwards, so it has both.

## What gets credited, and what does not

With a URL and token configured, the backfill asks Tracearr for that user's history and credits only what the replay could not account for:

- an item the replay already credited contributes **no first watch** here, which is what stops one viewing being counted twice
- an item Tracearr knows but the library cannot prove has been deleted, so its **earliest** play is a genuine first watch
- every later play of anything is a **rewatch**

Only plays Tracearr itself considers finished count, so an abandoned sample does not become a watch. Each play is credited on the date it happened, not today, so an old viewing cannot manufacture a streak.

Empty URL or empty token disables it completely. Absence is the off switch, so there is no separate enable flag to fall out of sync.

## Three decisions worth flagging

**Ordering.** The pass runs *before* the counter floor, not after. The floor restores each counter to its pre scan value, which already includes those deleted-media watches from back when they happened, so crediting them after the floor would stack them on top of themselves and inflate every total they feed. This one is easy to get backwards and the symptom would be silent.

**`TracearrCreditPlan` is a pure function.** The decision of what to credit is the one place where a mistake inflates real people's totals, and inflation cannot be walked back without the reset that loses everything else. Keeping it free of HTTP and service state means it can be tested exhaustively.

**`TryBuildBaseUri` does not reuse `WebhookUrlValidator`.** That one rejects private address ranges, which is right for a webhook meant to reach the outside world and wrong here: a self-hosted Tracearr is nearly always on the same LAN as Jellyfin, often the same host, so the check would reject the normal case. This value comes from a server admin in the plugin config, not from a user.

A Tracearr failure is logged and swallowed, since a backfill that credited the library correctly is still worth keeping.

## Tests

`TracearrBackfillTests`, 23 cases: the no-double-count rule, rewatch counting, deleted media getting exactly one first watch, oldest-play-first ordering, unfinished plays ignored, null safety, private addresses accepted, both fields required, GUID matching across hyphen and case, JSON mapping, and the admin page both loading and saving the two fields with the token masked.

I removed the no-double-count rule and confirmed two fail, rather than assuming they would. Full suite 140/140, Release build 0 warnings.

Happy to rework any of it. If you would rather this were a separate button instead of part of the existing scan, that is an easy change.
