### PR TITLE
fix: compute library completion during the scan, so its badges can unlock

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/LibraryCompletionWiringTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/LibraryCompletionWiringTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #79, first half. The library completion metric, its service and its
+/// five badges have existed for a while, but the only caller of the recompute
+/// was an endpoint nothing invokes, so the percentages stayed empty and those
+/// badges sat at zero on every install. These pin the wiring that fixes it.
+/// </summary>
+public class LibraryCompletionWiringTests
+{
+    [Fact]
+    public void TheBackfillCanReachTheCompletionService()
+    {
+        // The whole defect was that nothing called RecomputeForUser. If this
+        // dependency is ever dropped from the constructor, the percentages go
+        // back to never being computed, and the symptom is five badges quietly
+        // stuck at zero rather than an error.
+        var constructor = typeof(WatchHistoryBackfillService)
+            .GetConstructors()
+            .Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(LibraryCompletionService));
+    }
+
+    [Fact]
+    public void TheLibraryBadgesStillReadTheMetricTheyAlwaysDid()
+    {
+        // Guards the other end: wiring the producer is pointless if the badges
+        // stop reading it. Six, not five: the visible ladder plus the hidden
+        // Completionist Supreme, which also sits on 100.
+        var badges = AchievementDefinitions.All
+            .Where(d => d.Metric == AchievementMetric.LibraryCompletionPercent)
+            .ToList();
+
+        Assert.Equal(6, badges.Count);
+        Assert.Equal(
+            new[] { 10, 25, 50, 75, 100, 100 },
+            badges.Select(b => b.TargetValue).OrderBy(v => v).ToArray());
+        Assert.Contains(badges, b => b.Key == "hidden_completionist");
+    }
+
+    [Fact]
+    public void CompletionPercentagesSurviveARoundTripThroughTheCounters()
+    {
+        var counters = new UserAchievementCounters();
+        Assert.Equal(0, counters.BestLibraryCompletionPercent);
+        Assert.Equal(0, counters.LibrariesAt100PercentCount);
+
+        counters.LibraryCompletionPercents["Movies"] = 85;
+        counters.LibraryCompletionPercents["Shows"] = 100;
+
+        // The unparameterised reading is "your best library", which is what a
+        // badge like "reach 50% in any library" means.
+        Assert.Equal(100, counters.BestLibraryCompletionPercent);
+        Assert.Equal(1, counters.LibrariesAt100PercentCount);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -28,6 +28,7 @@ public class WatchHistoryBackfillService
     private readonly IUserManager _userManager;
     private readonly IUserDataManager _userDataManager;
     private readonly AchievementBadgeService _achievementBadgeService;
+    private readonly LibraryCompletionService _libraryCompletionService;
     private readonly ILogger<WatchHistoryBackfillService> _logger;
 
     public WatchHistoryBackfillService(
@@ -35,12 +36,14 @@ public class WatchHistoryBackfillService
         IUserManager userManager,
         IUserDataManager userDataManager,
         AchievementBadgeService achievementBadgeService,
+        LibraryCompletionService libraryCompletionService,
         ILogger<WatchHistoryBackfillService> logger)
     {
         _libraryManager = libraryManager;
         _userManager = userManager;
         _userDataManager = userDataManager;
         _achievementBadgeService = achievementBadgeService;
+        _libraryCompletionService = libraryCompletionService;
         _logger = logger;
     }
 
@@ -297,6 +300,24 @@ public class WatchHistoryBackfillService
             // Issue #48 companion: floor the rebuilt counters at their
             // pre scan values so deleted media never shrinks lifetime totals.
             _achievementBadgeService.ApplyCounterFloor(userId, preScanCounters);
+
+            // [issue #79] Library completion percentages come from the library
+            // itself, not from the replay, so nothing above computes them. The
+            // service and the five badges that read it have existed since the
+            // metric was added, but the only caller was an endpoint nothing
+            // invokes, which left the percentages empty and those badges stuck
+            // at zero on every install. The scan is the natural place: the
+            // library is already open and being enumerated far more heavily
+            // than two counting queries per library cost.
+            try
+            {
+                _libraryCompletionService.RecomputeForUser(userGuid);
+            }
+            catch (Exception ex)
+            {
+                // Never lose a good rebuild over the completion extra.
+                _logger.LogWarning(ex, "[AchievementBadges] Library completion recompute failed for {Username}.", username);
+            }
 
             _logger.LogInformation(
                 "[AchievementBadges] Backfill done for {Username}: {Movies} movies, {Episodes} episodes, {Series} series, {Books} books, {Libraries} libraries.",


### PR DESCRIPTION
First half of #79, the part I can prove on a live server.

`LibraryCompletionService`, `AchievementMetric.LibraryCompletionPercent` and six badges that read it already exist. What is missing is anything that triggers the recompute.

`POST users/{userId}/library-completion/recompute` is the only caller of `RecomputeForUser`, and nothing calls that endpoint: not the admin page, where the sole `LibraryCompletionPercent` occurrence is the metric option in the custom badge builder, not `standalone.js`, not `sidebar.js`, not the backfill.

## What that looks like on a real install

On my server, after months of use and several full scans:

- `LibraryCompletionPercents` is `{}`
- 68 movies and 2813 episodes in the library, 626 items watched by the account I checked
- `library_explorer`, `library_quarter`, `library_half`, `library_three_quarter`, `library_complete` and `hidden_completionist` all sit at 0 of their targets

There is nothing wrong with the data. The producer simply never runs, so six badges are unreachable through normal use.

## The change

Call `RecomputeForUser` at the end of the backfill. The library is already open and being enumerated far more heavily than this costs: two counting queries per library, both already using `EnableTotalRecordCount = false`. A failure is logged and swallowed, since a good rebuild should not be lost over the completion extra.

## Tests

`LibraryCompletionWiringTests`, three of them: the backfill can reach the service, the six badges still read the metric, and the counters round-trip with `BestLibraryCompletionPercent` meaning "your best library", which is what "reach 50% in any library" asks for.

I removed the wiring and confirmed the first one fails. Full suite 120/120, Release build clean.

One thing the tests caught that I had wrong: I said five badges in #79, it is six. `hidden_completionist` also sits on this metric at 100.

The artist half of #79 comes as a separate PR, because I have no music in my library and cannot validate it against real data the way I can validate this one. Keeping them apart means this one does not have to wait on that.
