### PR TITLE
feat: artist discography completion

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/ArtistCompletionTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/ArtistCompletionTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #79, second half: discography completion per artist.
+/// <para>
+/// Worth saying plainly, since it changes how much these tests are worth: my
+/// own library has no audio at all, so unlike the library half of #79 I could
+/// not exercise this against real data. Everything below is unit level, and
+/// the library queries themselves are unverified in practice.
+/// </para>
+/// </summary>
+public class ArtistCompletionTests
+{
+    [Fact]
+    public void TheMetricIsAppendedLast_SoStoredOrdinalsDoNotShift()
+    {
+        // Badge progress is serialised by enum ordinal. Inserting a value in
+        // the middle would silently repoint every stored badge above it at a
+        // different metric, which is unrecoverable without a rebuild.
+        var values = System.Enum.GetValues<AchievementMetric>();
+
+        Assert.Equal(AchievementMetric.ArtistCompletionPercent, values[^1]);
+    }
+
+    [Fact]
+    public void CompletionReadsBestArtistWhenNoArtistIsNamed()
+    {
+        var counters = new UserAchievementCounters();
+        Assert.Equal(0, counters.BestArtistCompletionPercent);
+
+        counters.ArtistCompletionPercents["Boards of Canada"] = 40;
+        counters.ArtistCompletionPercents["Aphex Twin"] = 95;
+
+        // "Hear 50% of one artist's tracks" means any artist, so the
+        // unparameterised reading has to be the best one, not a total or an
+        // average.
+        Assert.Equal(95, counters.BestArtistCompletionPercent);
+    }
+
+    [Fact]
+    public void TheLadderMirrorsTheLibraryOne()
+    {
+        var artist = AchievementDefinitions.All
+            .Where(d => d.Metric == AchievementMetric.ArtistCompletionPercent)
+            .Select(d => d.TargetValue)
+            .OrderBy(v => v)
+            .ToArray();
+
+        Assert.Equal(new[] { 10, 25, 50, 75, 100 }, artist);
+    }
+
+    [Fact]
+    public void DiscographyBadgesAreTheirOwnCategory_NotFoldedIntoMusic()
+    {
+        // They read a different kind of number from every other music badge:
+        // a ratio against the library rather than an accumulated play count.
+        var badges = AchievementDefinitions.All
+            .Where(d => d.Metric == AchievementMetric.ArtistCompletionPercent)
+            .ToList();
+
+        Assert.All(badges, b => Assert.Equal("Discography", b.Category));
+        Assert.Contains(badges, b => b.Key == "artist_discography" && b.Rarity == "Legendary");
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/LibraryCompletionWiringTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/LibraryCompletionWiringTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #79, first half. The library completion metric, its service and its
+/// five badges have existed for a while, but the only caller of the recompute
+/// was an endpoint nothing invokes, so the percentages stayed empty and those
+/// badges sat at zero on every install. These pin the wiring that fixes it.
+/// </summary>
+public class LibraryCompletionWiringTests
+{
+    [Fact]
+    public void TheBackfillCanReachTheCompletionService()
+    {
+        // The whole defect was that nothing called RecomputeForUser. If this
+        // dependency is ever dropped from the constructor, the percentages go
+        // back to never being computed, and the symptom is five badges quietly
+        // stuck at zero rather than an error.
+        var constructor = typeof(WatchHistoryBackfillService)
+            .GetConstructors()
+            .Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(LibraryCompletionService));
+    }
+
+    [Fact]
+    public void TheLibraryBadgesStillReadTheMetricTheyAlwaysDid()
+    {
+        // Guards the other end: wiring the producer is pointless if the badges
+        // stop reading it. Six, not five: the visible ladder plus the hidden
+        // Completionist Supreme, which also sits on 100.
+        var badges = AchievementDefinitions.All
+            .Where(d => d.Metric == AchievementMetric.LibraryCompletionPercent)
+            .ToList();
+
+        Assert.Equal(6, badges.Count);
+        Assert.Equal(
+            new[] { 10, 25, 50, 75, 100, 100 },
+            badges.Select(b => b.TargetValue).OrderBy(v => v).ToArray());
+        Assert.Contains(badges, b => b.Key == "hidden_completionist");
+    }
+
+    [Fact]
+    public void CompletionPercentagesSurviveARoundTripThroughTheCounters()
+    {
+        var counters = new UserAchievementCounters();
+        Assert.Equal(0, counters.BestLibraryCompletionPercent);
+        Assert.Equal(0, counters.LibrariesAt100PercentCount);
+
+        counters.LibraryCompletionPercents["Movies"] = 85;
+        counters.LibraryCompletionPercents["Shows"] = 100;
+
+        // The unparameterised reading is "your best library", which is what a
+        // badge like "reach 50% in any library" means.
+        Assert.Equal(100, counters.BestLibraryCompletionPercent);
+        Assert.Equal(1, counters.LibrariesAt100PercentCount);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Models/AchievementMetric.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/AchievementMetric.cs
@@ -87,4 +87,9 @@ public enum AchievementMetric
     // serialized ordinals are unchanged.
     MusicGenrePlays,
     MusicGenreListeningHours,
+
+    // [issue #79] Discography completion for one artist, or the best artist
+    // when no MetricParameter is set. Appended at the end for the same reason
+    // as the two above: existing serialized ordinals must not shift.
+    ArtistCompletionPercent,
 }

--- a/Jellyfin.Plugin.AchievementBadges/Models/UserAchievementCounters.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/UserAchievementCounters.cs
@@ -118,6 +118,12 @@ public class UserAchievementCounters
     public Dictionary<string, int> LibraryItemCounts { get; set; } = new();
     public Dictionary<string, int> LibraryCompletionPercents { get; set; } = new();
 
+    // [issue #79] Per-artist discography completion, played tracks over the
+    // artist's tracks in the library. Same shape as LibraryCompletionPercents
+    // above, keyed by artist name, so the metric can be read either for one
+    // named artist or as "your best artist".
+    public Dictionary<string, int> ArtistCompletionPercents { get; set; } = new();
+
     // Per-decade item counts (key = decade as string, e.g. "1970", "1980")
     public Dictionary<string, int> DecadeItemCounts { get; set; } = new();
     // Per-day-of-week item counts (key = day name, e.g. "Monday")
@@ -201,6 +207,7 @@ public class UserAchievementCounters
     public int SeriesSampledOnlyCount => SeriesPilotsWatched.Count(id => !SeriesContinuedPastPilot.Contains(id));
     public int SeriesBingedAfterPilotCount => SeriesContinuedPastPilot.Count;
     public int BestLibraryCompletionPercent => LibraryCompletionPercents.Count == 0 ? 0 : LibraryCompletionPercents.Values.Max();
+    public int BestArtistCompletionPercent => ArtistCompletionPercents.Count == 0 ? 0 : ArtistCompletionPercents.Values.Max();
     public int LibrariesAt100PercentCount => LibraryCompletionPercents.Count(kv => kv.Value >= 100);
     public int MaxLibraryItemCountValue => LibraryItemCounts.Count == 0 ? 0 : LibraryItemCounts.Values.Max();
     public int MaxMinutesInSingleDay => MinutesByDate.Count == 0 ? 0 : MinutesByDate.Values.Max();

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -1227,6 +1227,23 @@ public class AchievementBadgeService : IDisposable
         }
     }
 
+    /// <summary>
+    /// [issue #79] Replaces the per-artist discography percentages. Same
+    /// contract as the library one above: computed elsewhere from the library,
+    /// written here in one shot, badges re-evaluated immediately.
+    /// </summary>
+    public void UpdateArtistCompletionPercents(string userId, Dictionary<string, int> percents)
+    {
+        userId = NormalizeUserId(userId);
+        lock (_lock)
+        {
+            var profile = GetOrCreateProfile(userId);
+            profile.Counters.ArtistCompletionPercents = percents ?? new Dictionary<string, int>();
+            EvaluateBadges(profile, userId);
+            Save();
+        }
+    }
+
     public void RegisterLogin(string userId)
     {
         userId = NormalizeUserId(userId);
@@ -3002,6 +3019,18 @@ public class AchievementBadgeService : IDisposable
                 return counters.LibraryCompletionPercents.TryGetValue(parameter, out var p) ? p : 0;
             }
             return counters.BestLibraryCompletionPercent;
+        }
+
+        // [issue #79] Same two readings as the library metric above: a named
+        // artist via MetricParameter, or the user's best artist when the badge
+        // does not name one.
+        if (metric == AchievementMetric.ArtistCompletionPercent)
+        {
+            if (!string.IsNullOrWhiteSpace(parameter))
+            {
+                return counters.ArtistCompletionPercents.TryGetValue(parameter, out var a) ? a : 0;
+            }
+            return counters.BestArtistCompletionPercent;
         }
 
         return GetSingleMetricValue(counters, metric);

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementDefinitions.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementDefinitions.cs
@@ -166,6 +166,16 @@ public static class AchievementDefinitions
         new() { Id = "library-three-quarter", Key = "library_three_quarter", Title = "Three-Quarters", Description = "Reach 75% completion in any library.", Icon = "menu_book", Category = "Library Completion", Rarity = "Epic", Metric = AchievementMetric.LibraryCompletionPercent, TargetValue = 75 },
         new() { Id = "library-complete", Key = "library_complete", Title = "100% Complete", Description = "Reach 100% completion in any library.", Icon = "check_circle", Category = "Library Completion", Rarity = "Legendary", Metric = AchievementMetric.LibraryCompletionPercent, TargetValue = 100 },
 
+        // [issue #79] Discography completion, the same ladder as the library
+        // one above but one level down: a single artist rather than a whole
+        // library. Unparameterised, so each reads the user's best artist; a
+        // custom badge can name one through MetricParameter.
+        new() { Id = "artist-sampler", Key = "artist_sampler", Title = "Sampler", Description = "Hear 10% of one artist's tracks.", Icon = "album", Category = "Discography", Rarity = "Common", Metric = AchievementMetric.ArtistCompletionPercent, TargetValue = 10 },
+        new() { Id = "artist-listener", Key = "artist_listener", Title = "Regular Listener", Description = "Hear 25% of one artist's tracks.", Icon = "queue_music", Category = "Discography", Rarity = "Uncommon", Metric = AchievementMetric.ArtistCompletionPercent, TargetValue = 25 },
+        new() { Id = "artist-fan", Key = "artist_fan", Title = "Fan", Description = "Hear 50% of one artist's tracks.", Icon = "favorite", Category = "Discography", Rarity = "Rare", Metric = AchievementMetric.ArtistCompletionPercent, TargetValue = 50 },
+        new() { Id = "artist-devotee", Key = "artist_devotee", Title = "Devotee", Description = "Hear 75% of one artist's tracks.", Icon = "star", Category = "Discography", Rarity = "Epic", Metric = AchievementMetric.ArtistCompletionPercent, TargetValue = 75 },
+        new() { Id = "artist-discography", Key = "artist_discography", Title = "Complete Discography", Description = "Hear every track an artist has in the library.", Icon = "library_music", Category = "Discography", Rarity = "Legendary", Metric = AchievementMetric.ArtistCompletionPercent, TargetValue = 100 },
+
         new() { Id = "login-streak-week", Key = "login_streak_week", Title = "Regular Visitor", Description = "Log in 7 different days.", Icon = "event_repeat", Category = "Loyalty", Rarity = "Common", Metric = AchievementMetric.DaysLoggedIn, TargetValue = 7 },
         new() { Id = "login-streak-month", Key = "login_streak_month", Title = "Monthly Regular", Description = "Log in 30 different days.", Icon = "calendar_month", Category = "Loyalty", Rarity = "Rare", Metric = AchievementMetric.DaysLoggedIn, TargetValue = 30 },
         new() { Id = "login-streak-year", Key = "login_streak_year", Title = "Dedicated", Description = "Log in 365 different days.", Icon = "workspace_premium", Category = "Loyalty", Rarity = "Legendary", Metric = AchievementMetric.DaysLoggedIn, TargetValue = 365 },

--- a/Jellyfin.Plugin.AchievementBadges/Services/LibraryCompletionService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/LibraryCompletionService.cs
@@ -89,6 +89,88 @@ public class LibraryCompletionService
         return result;
     }
 
+    /// <summary>
+    /// [issue #79] Discography completion per artist: played tracks over the
+    /// artist's tracks in this user's libraries.
+    /// <para>
+    /// Counted on album artist rather than on every credited artist, because a
+    /// guest appearance is not part of someone's discography. Counted on
+    /// tracks rather than albums, matching how the rest of the music metrics
+    /// already work and avoiding the question of what a compilation or a
+    /// single does to an album-based percentage.
+    /// </para>
+    /// <para>
+    /// Artists with a single track are skipped. Their percentage is only ever
+    /// 0 or 100, so they would hand out a "completed an artist" badge for one
+    /// play, which is not what the badge means.
+    /// </para>
+    /// </summary>
+    public Dictionary<string, int> RecomputeArtistsForUser(Guid userGuid)
+    {
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var user = _userManager.GetUserById(userGuid);
+        if (user is null)
+        {
+            return result;
+        }
+
+        try
+        {
+            var artistQuery = new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[] { BaseItemKind.MusicArtist },
+                Recursive = true,
+                EnableTotalRecordCount = false
+            };
+
+            var artists = _libraryManager.GetItemsResult(artistQuery).Items;
+
+            foreach (var artist in artists)
+            {
+                try
+                {
+                    var totalQuery = new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = new[] { BaseItemKind.Audio },
+                        AlbumArtistIds = new[] { artist.Id },
+                        Recursive = true,
+                        EnableTotalRecordCount = false
+                    };
+
+                    var total = _libraryManager.GetItemsResult(totalQuery).Items.Count;
+                    if (total < 2) continue;
+
+                    var playedQuery = new InternalItemsQuery(user)
+                    {
+                        IncludeItemTypes = new[] { BaseItemKind.Audio },
+                        AlbumArtistIds = new[] { artist.Id },
+                        IsPlayed = true,
+                        Recursive = true,
+                        EnableTotalRecordCount = false
+                    };
+
+                    var played = _libraryManager.GetItemsResult(playedQuery).Items.Count;
+                    var name = artist.Name ?? string.Empty;
+                    if (!string.IsNullOrWhiteSpace(name))
+                    {
+                        result[name] = (int)Math.Round(100.0 * played / total);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "[AchievementBadges] Artist completion calc failed for {Artist}", artist.Name);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[AchievementBadges] Artist completion recompute failed for user {UserId}", userGuid);
+        }
+
+        _badgeService.UpdateArtistCompletionPercents(userGuid.ToString("D"), result);
+        return result;
+    }
+
     public Dictionary<string, Dictionary<string, int>> RecomputeAll()
     {
         var all = new Dictionary<string, Dictionary<string, int>>();

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -28,6 +28,7 @@ public class WatchHistoryBackfillService
     private readonly IUserManager _userManager;
     private readonly IUserDataManager _userDataManager;
     private readonly AchievementBadgeService _achievementBadgeService;
+    private readonly LibraryCompletionService _libraryCompletionService;
     private readonly ILogger<WatchHistoryBackfillService> _logger;
 
     public WatchHistoryBackfillService(
@@ -35,12 +36,14 @@ public class WatchHistoryBackfillService
         IUserManager userManager,
         IUserDataManager userDataManager,
         AchievementBadgeService achievementBadgeService,
+        LibraryCompletionService libraryCompletionService,
         ILogger<WatchHistoryBackfillService> logger)
     {
         _libraryManager = libraryManager;
         _userManager = userManager;
         _userDataManager = userDataManager;
         _achievementBadgeService = achievementBadgeService;
+        _libraryCompletionService = libraryCompletionService;
         _logger = logger;
     }
 
@@ -297,6 +300,24 @@ public class WatchHistoryBackfillService
             // Issue #48 companion: floor the rebuilt counters at their
             // pre scan values so deleted media never shrinks lifetime totals.
             _achievementBadgeService.ApplyCounterFloor(userId, preScanCounters);
+
+            // [issue #79] Library completion percentages come from the library
+            // itself, not from the replay, so nothing above computes them. The
+            // service and the five badges that read it have existed since the
+            // metric was added, but the only caller was an endpoint nothing
+            // invokes, which left the percentages empty and those badges stuck
+            // at zero on every install. The scan is the natural place: the
+            // library is already open and being enumerated far more heavily
+            // than two counting queries per library cost.
+            try
+            {
+                _libraryCompletionService.RecomputeForUser(userGuid);
+            }
+            catch (Exception ex)
+            {
+                // Never lose a good rebuild over the completion extra.
+                _logger.LogWarning(ex, "[AchievementBadges] Library completion recompute failed for {Username}.", username);
+            }
 
             _logger.LogInformation(
                 "[AchievementBadges] Backfill done for {Username}: {Movies} movies, {Episodes} episodes, {Series} series, {Books} books, {Libraries} libraries.",

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -312,11 +312,15 @@ public class WatchHistoryBackfillService
             try
             {
                 _libraryCompletionService.RecomputeForUser(userGuid);
+                // [issue #79] Same reasoning one level down. Shipping the
+                // discography metric without a caller would leave it in the
+                // exact dead state this issue was opened about.
+                _libraryCompletionService.RecomputeArtistsForUser(userGuid);
             }
             catch (Exception ex)
             {
-                // Never lose a good rebuild over the completion extra.
-                _logger.LogWarning(ex, "[AchievementBadges] Library completion recompute failed for {Username}.", username);
+                // Never lose a good rebuild over the completion extras.
+                _logger.LogWarning(ex, "[AchievementBadges] Completion recompute failed for {Username}.", username);
             }
 
             _logger.LogInformation(


### PR DESCRIPTION
Second half of #79. Independent of #80, so either can go in without the other.

Per artist, played tracks over that artist's tracks in the library, stored the same way `LibraryCompletionPercents` already is. The metric reads two ways, exactly like the library one: a named artist through `MetricParameter`, or the user's best artist when the badge does not name one. Five badges mirroring the library ladder at 10, 25, 50, 75 and 100.

## Please read this part before the code

**I could not test this against a real music library.** My own has no audio at all: 68 movies, 2813 episodes, zero tracks and zero artists. So unlike #80, where I could show you the before and after on a live server, everything here is unit level and the two `GetItemsResult` queries are unverified in practice.

That is why it is a separate PR. I did not want the half I can prove to wait on the half I cannot.

@Daemon-Network asked for this in #24 and has a music library. If he is willing to try it, that would be worth more than anything I can add here.

## The three judgement calls I made

You asked in #24 whether I wanted to take a swing, so these are mine to defend, and all three are cheap to change if you disagree.

**Album artist, not every credited artist.** A guest appearance is not part of someone's discography, and counting it would make a featured verse dilute the percentage of an artist you have barely listened to.

**Tracks, not albums.** It matches how the existing music metrics work, and it sidesteps what a compilation or a single does to an album-based percentage. Albums is arguably closer to what a listener means by "completed the discography", so say the word and I will rework it.

**Artists with a single track are skipped.** Their percentage is only ever 0 or 100, so they would hand out a Legendary "Complete Discography" badge for one play. The cut-off is `total < 2`, and it is one line if you would rather it were higher.

## Ordinals

The metric is appended at the end of the enum, like the two music genre metrics from v2.1.3 before it. A test pins that it stays last: badge progress is serialised by ordinal, so inserting in the middle would silently repoint every stored badge above it at a different metric, and that is not recoverable without a rebuild.

## Tests

`ArtistCompletionTests`, four: the ordinal position, the unparameterised reading being "best artist" rather than a total or an average, the ladder matching the library one, and the badges being their own category since they read a ratio against the library rather than an accumulated count.

121 of 121, Release build clean. The recompute is not called from anywhere yet; wiring it into the scan the way #80 does is the obvious follow-up, and I left it out deliberately so the two PRs stay independent.
