### PR TITLE
ci: bump the whole codeql-action family to v4.36.2 in one step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
           dotnet-version: "9.0.x"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: csharp
           queries: security-extended,security-and-quality
@@ -44,6 +44,6 @@ jobs:
           dotnet build Jellyfin.Plugin.AchievementBadges/Jellyfin.Plugin.AchievementBadges.csproj --configuration Release --no-restore
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:csharp"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,6 +53,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to GitHub code-scanning
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Replaces #33 and #34, which should be closed if you take this.

Dependabot split the codeql-action bump into two PRs, one for `init` and one for `analyze`. **Each fails on its own**, and both fail at exactly the same place: the `Perform CodeQL Analysis` step. They bump halves of a pair that has to be on the same version, so whichever you merge first leaves the workflow broken until the second lands.

This does both in one commit, and adds a third that dependabot missed: `upload-sarif` in `scorecard.yml`, still on v4.36.0. All three are the same action from the same repository and were pinned to the same commit before this drifted, so keeping them in lockstep is the state they are meant to be in.

I have not reproduced the failure locally, since it needs the CodeQL runner. What I can say is that both PRs fail at the analyze step and each changes only one half of the pair, which is the shape a version mismatch takes. If CI passes here with all three moved together, that confirms it.

---

While I was in there, the state of the other five, since you asked me to look at the batch:

| PR | Verdict |
|---|---|
| #31 `actions/checkout` v6 to v7 | safe to merge |
| #32 `actions/cache` v5 to v6 | safe to merge |
| #35 `actions/setup-dotnet` 5.3.0 to 5.4.0 | safe to merge |
| #39 `Microsoft.CodeAnalysis.NetAnalyzers` 10.0.300 to 10.0.302 | safe to merge, verified by building |
| #58 oss-fuzz base-builder digest | safe to merge |

The two I actually worried about:

**#31, checkout v7.** The only behavioural change in v7 is that it blocks checking out a fork PR under `pull_request_target` and `workflow_run`. No workflow here uses either trigger: they are `push`, `pull_request`, `schedule`, `workflow_dispatch` and `branch_protection_rule`. Every job runs on `ubuntu-latest`, so the ESM migration is fine too. Nothing to change.

**#39, the analyzer bump.** This one can actually fail a build, since the project sets `TreatWarningsAsErrors`, so any new diagnostic becomes an error. I applied it locally and built Release: **0 warnings, 0 errors**. The PR also includes the updated `packages.lock.json`, which matters because CI restores with `--locked-mode` and would otherwise fail on drift.

**#32, cache v6** is an ESM migration plus read-only cache handling, no input changes, and this repo uses only `path`, `key` and `restore-keys`.

One caveat on all of them: they were opened around 1 July and their CI results predate everything merged today, so it may be worth letting them rerun before merging.
