### PR TITLE
feat(tracearr): a standalone sync button, made idempotent by a ledger

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/TracearrLedgerTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TracearrLedgerTests.cs
@@ -139,6 +139,28 @@ public class TracearrLedgerTests : IDisposable
     }
 
     [Fact]
+    public void AnEmptyLedgerIsNotEvidenceThatNothingWasCredited()
+    {
+        // The upgrade case, and the one that actually bit. A profile scanned
+        // under a version without a ledger has counters that already include
+        // Tracearr credits, and an empty ledger that cannot say so. Treating
+        // empty as "nothing counted yet" doubles every one of them: measured
+        // on a live upgrade, RewatchCount went 6 to 12 on the first press.
+        //
+        // So the caller has to distinguish "no record" from "record says
+        // nothing", which it can only do by asking whether the set is empty
+        // before it decides to credit.
+        var ledger = new TracearrCreditLedger(Path_);
+
+        Assert.Empty(ledger.For("never-synced"));
+
+        // After adopting, the same emptiness check tells the opposite story,
+        // which is what stops the second press crediting.
+        ledger.Remember("never-synced", new[] { "chain-1", "chain-2" });
+        Assert.Equal(2, ledger.For("never-synced").Count);
+    }
+
+    [Fact]
     public void ACorruptLedgerDoesNotStopTheServiceStarting()
     {
         File.WriteAllText(Path_, "{ this is not json");

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TracearrLedgerTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TracearrLedgerTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// The standalone Tracearr sync writes onto live counters, with no reset in
+/// front of it. Everything that stops it double crediting lives here, so these
+/// pin the one failure that cannot be undone: pressing the button twice and
+/// counting the same viewings again.
+/// </summary>
+public class TracearrLedgerTests : IDisposable
+{
+    private readonly string _dir;
+
+    public TracearrLedgerTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "abledger_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private string Path_ => Path.Combine(_dir, "tracearr-credited.json");
+
+    private static TracearrPlay Play(string id, string ratingKey, string startedAt)
+        => new()
+        {
+            Id = id,
+            RatingKey = ratingKey,
+            MediaType = "movie",
+            Watched = true,
+            StartedAt = DateTimeOffset.Parse(startedAt, System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+    [Fact]
+    public void PressingTheButtonTwiceCreditsNothingTheSecondTime()
+    {
+        // The whole reason the ledger exists.
+        var ledger = new TracearrCreditLedger(Path_);
+        var plays = new[]
+        {
+            Play("chain-1", "item-a", "2026-01-01T10:00:00Z"),
+            Play("chain-2", "item-a", "2026-02-01T10:00:00Z")
+        };
+
+        var first = TracearrCreditPlan.Build(plays, new HashSet<string>(), ledger.For("u1"));
+        Assert.Equal(2, first.Count);
+        ledger.Remember("u1", first.Select(c => c.Play.Id!));
+
+        var second = TracearrCreditPlan.Build(plays, new HashSet<string>(), ledger.For("u1"));
+        Assert.Empty(second);
+    }
+
+    [Fact]
+    public void ANewPlayIsStillCreditedAfterAnEarlierSync()
+    {
+        var ledger = new TracearrCreditLedger(Path_);
+        ledger.Remember("u1", new[] { "chain-1" });
+
+        var plan = TracearrCreditPlan.Build(
+            new[] { Play("chain-1", "item-a", "2026-01-01T10:00:00Z"), Play("chain-2", "item-a", "2026-02-01T10:00:00Z") },
+            new HashSet<string>(),
+            ledger.For("u1"));
+
+        // Only the one it has not seen, and it is still a rewatch: skipping a
+        // credited play must not promote a later one to first watch.
+        Assert.Single(plan);
+        Assert.Equal("chain-2", plan[0].Play.Id);
+        Assert.True(plan[0].IsRewatch);
+    }
+
+    [Fact]
+    public void ForgettingAUserLetsTheirPlaysCountAgain()
+    {
+        // What a reset does. Without this the user would be permanently
+        // missing every play credited before the reset wiped the counters.
+        var ledger = new TracearrCreditLedger(Path_);
+        ledger.Remember("u1", new[] { "chain-1" });
+        Assert.Single(ledger.For("u1"));
+
+        ledger.Forget("u1");
+
+        Assert.Empty(ledger.For("u1"));
+    }
+
+    [Fact]
+    public void OneUsersLedgerDoesNotAffectAnother()
+    {
+        var ledger = new TracearrCreditLedger(Path_);
+        ledger.Remember("u1", new[] { "chain-1" });
+
+        Assert.Empty(ledger.For("u2"));
+    }
+
+    [Fact]
+    public void UserIdsMatchAcrossHyphenAndCase()
+    {
+        // The same GUID reaches this from the API route, the scan and the
+        // profile store in three different shapes. A miss here would silently
+        // credit everything twice.
+        var ledger = new TracearrCreditLedger(Path_);
+        ledger.Remember("5DD06EE5-CED1-4CEE-A5E5-CBC29D2425C4", new[] { "chain-1" });
+
+        Assert.Single(ledger.For("5dd06ee5ced14ceea5e5cbc29d2425c4"));
+    }
+
+    [Fact]
+    public void TheLedgerSurvivesARestart()
+    {
+        // It is written to disk for exactly one reason: a restart between two
+        // presses must not re-credit everything.
+        new TracearrCreditLedger(Path_).Remember("u1", new[] { "chain-1", "chain-2" });
+
+        var reloaded = new TracearrCreditLedger(Path_);
+
+        Assert.Equal(2, reloaded.For("u1").Count);
+        Assert.Contains("chain-1", reloaded.For("u1"));
+    }
+
+    [Fact]
+    public void RememberReportsOnlyWhatWasActuallyNew()
+    {
+        // So the button can say "nothing new" honestly instead of claiming
+        // work it did not do.
+        var ledger = new TracearrCreditLedger(Path_);
+
+        Assert.Equal(2, ledger.Remember("u1", new[] { "a", "b" }));
+        Assert.Equal(1, ledger.Remember("u1", new[] { "b", "c" }));
+        Assert.Equal(0, ledger.Remember("u1", new[] { "a", "b", "c" }));
+    }
+
+    [Fact]
+    public void ACorruptLedgerDoesNotStopTheServiceStarting()
+    {
+        File.WriteAllText(Path_, "{ this is not json");
+
+        var ledger = new TracearrCreditLedger(Path_);
+
+        Assert.Empty(ledger.For("u1"));
+        Assert.NotNull(ledger.LastPersistError);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -927,6 +927,16 @@ public class AchievementBadgesController : ControllerBase
         return Ok(result);
     }
 
+    // [issue #45 button] Credits Tracearr plays without the reset and replay a
+    // full scan does. Idempotent by ledger: pressing it again credits nothing.
+    [HttpPost("users/{userId}/tracearr-sync")]
+    [Authorize(Policy = "RequiresElevation")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult SyncTracearr([FromRoute] string userId)
+    {
+        return Ok(_backfillService.SyncTracearrForUser(userId));
+    }
+
     [HttpPost("backfill-all")]
     [Authorize(Policy = "RequiresElevation")]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/TracearrCreditLedger.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/TracearrCreditLedger.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// Remembers which Tracearr plays have already been credited to each user.
+/// <para>
+/// The scan can credit blindly because it resets the profile first: it writes
+/// onto counters that were just wiped. A standalone sync has nothing wiping
+/// anything, so without a record of what was already counted, pressing the
+/// button twice credits every play twice. Rewatch counts double, totals
+/// inflate, and there is no way back except the reset that loses everything
+/// else. This is that record.
+/// </para>
+/// <para>
+/// Keyed by user and by Tracearr's own play id, which is stable across calls,
+/// so the same play is recognised no matter how the history is paged.
+/// </para>
+/// </summary>
+public sealed class TracearrCreditLedger
+{
+    private sealed class FileShape
+    {
+        public Dictionary<string, List<string>> CreditedByUser { get; set; } = new();
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    private readonly ConcurrentDictionary<string, HashSet<string>> _byUser =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly string? _persistPath;
+    private readonly object _fileLock = new();
+
+    /// <summary>Last write failure, or null. Surfaced rather than thrown: a
+    /// ledger that cannot be written must not take a working sync down with
+    /// it, but silently forgetting would reintroduce double crediting, so the
+    /// caller needs to be able to see it.</summary>
+    public string? LastPersistError { get; private set; }
+
+    public TracearrCreditLedger(string? persistPath = null)
+    {
+        _persistPath = persistPath;
+        Load();
+    }
+
+    /// <summary>Play ids already credited to this user.</summary>
+    public IReadOnlySet<string> For(string userId)
+    {
+        return _byUser.TryGetValue(Key(userId), out var set)
+            ? set
+            : (IReadOnlySet<string>)new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Records ids as credited. Returns how many were new, so a
+    /// caller can report "nothing to do" honestly instead of claiming work it
+    /// did not perform.</summary>
+    public int Remember(string userId, IEnumerable<string> playIds)
+    {
+        if (playIds is null) return 0;
+
+        var set = _byUser.GetOrAdd(Key(userId), static _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        var added = 0;
+
+        lock (set)
+        {
+            foreach (var id in playIds)
+            {
+                if (!string.IsNullOrWhiteSpace(id) && set.Add(id)) added++;
+            }
+        }
+
+        if (added > 0) Persist();
+        return added;
+    }
+
+    /// <summary>
+    /// Drops everything remembered for a user. Called when their profile is
+    /// reset: after a reset those plays genuinely do need crediting again, so
+    /// keeping the ledger would leave the user permanently missing them. This
+    /// is what makes the design correct rather than merely safe against
+    /// double clicks.
+    /// </summary>
+    public void Forget(string userId)
+    {
+        if (_byUser.TryRemove(Key(userId), out _)) Persist();
+    }
+
+    private static string Key(string? userId)
+        => (userId ?? string.Empty).Replace("-", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
+
+    private void Load()
+    {
+        if (string.IsNullOrEmpty(_persistPath) || !File.Exists(_persistPath)) return;
+
+        try
+        {
+            var file = JsonSerializer.Deserialize<FileShape>(File.ReadAllText(_persistPath));
+            if (file?.CreditedByUser is null) return;
+
+            foreach (var pair in file.CreditedByUser)
+            {
+                _byUser[Key(pair.Key)] = new HashSet<string>(pair.Value ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A corrupt ledger reads as "nothing credited yet". That risks one
+            // round of double crediting, which is bad, but refusing to start
+            // is worse, and the alternative of guessing is not available.
+            LastPersistError = "read " + _persistPath + ": " + ex.Message;
+        }
+    }
+
+    private void Persist()
+    {
+        if (string.IsNullOrEmpty(_persistPath)) return;
+
+        try
+        {
+            var file = new FileShape();
+            foreach (var pair in _byUser)
+            {
+                lock (pair.Value)
+                {
+                    file.CreditedByUser[pair.Key] = new List<string>(pair.Value);
+                }
+            }
+
+            var json = JsonSerializer.Serialize(file, SerializerOptions);
+
+            lock (_fileLock)
+            {
+                var directory = Path.GetDirectoryName(_persistPath);
+                if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+
+                // Written aside and moved into place, so a shutdown mid-write
+                // cannot leave a truncated ledger that reads as "nothing
+                // credited" and re-credits everything on the next sync.
+                var temporary = _persistPath + ".tmp";
+                File.WriteAllText(temporary, json);
+                File.Move(temporary, _persistPath, overwrite: true);
+            }
+
+            LastPersistError = null;
+        }
+        catch (Exception ex)
+        {
+            LastPersistError = "write " + _persistPath + ": " + ex.Message;
+        }
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/TracearrCreditPlan.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/TracearrCreditPlan.cs
@@ -38,12 +38,16 @@ public static class TracearrCreditPlan
     /// count however many times an item was played.</item>
     /// </list>
     /// </summary>
-    public static List<Credit> Build(IEnumerable<TracearrPlay>? plays, ISet<string>? alreadyCredited)
+    public static List<Credit> Build(
+        IEnumerable<TracearrPlay>? plays,
+        ISet<string>? alreadyCredited,
+        IReadOnlySet<string>? alreadyCreditedPlayIds = null)
     {
         var result = new List<Credit>();
         if (plays is null) return result;
 
         var seen = alreadyCredited ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ledger = alreadyCreditedPlayIds ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         var groups = plays
             .Where(p => p is not null && p.Watched && !string.IsNullOrWhiteSpace(p.RatingKey))
@@ -63,6 +67,12 @@ public static class TracearrCreditPlan
             for (var i = 0; i < ordered.Count; i++)
             {
                 if (libraryAlreadyCreditedIt && i == 0) continue;
+
+                // Already counted on a previous sync. Skipped after the
+                // position check, not before, so removing it from the list
+                // cannot shift which play counts as the first watch.
+                if (!string.IsNullOrWhiteSpace(ordered[i].Id) && ledger.Contains(ordered[i].Id!)) continue;
+
                 result.Add(new Credit(ordered[i], libraryAlreadyCreditedIt || i > 0));
             }
         }

--- a/Jellyfin.Plugin.AchievementBadges/Models/TracearrPlay.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/TracearrPlay.cs
@@ -10,6 +10,13 @@ namespace Jellyfin.Plugin.AchievementBadges.Models;
 public class TracearrPlay
 {
     /// <summary>
+    /// Tracearr's own id for this play, its chain id. Stable across calls and
+    /// across paging, which is what lets a standalone sync tell a play it has
+    /// already credited from one it has not.
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
     /// The media server's own item id, Tracearr's <c>rating_key</c>. For a
     /// Jellyfin server this is the item GUID, which is what lets a play be
     /// matched against what the library replay already credited.

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -1588,6 +1588,10 @@ font-size:0.88em;
                         <button is="emby-button" type="button" class="raised" id="abBackfillAllBtn" data-i18n="admin.btn_scan_all_users">
                             Scan all users
                         </button>
+
+                        <button is="emby-button" type="button" class="raised" id="abTracearrSyncBtn" data-i18n="admin.btn_tracearr_sync">
+                            Sync Tracearr
+                        </button>
                     </div>
                 </details>
 
@@ -3126,6 +3130,32 @@ font-size:0.88em;
         }).catch(function (err) {
             setStatus('');
             setError(tr('admin.msg.backfill_failed', 'Backfill failed.') + ' ' + (err && err.message ? err.message : String(err)));
+        });
+    });
+
+    var tracearrSyncBtn = document.getElementById('abTracearrSyncBtn');
+    if (tracearrSyncBtn) tracearrSyncBtn.addEventListener('click', function () {
+        var userId = getUserId();
+        if (!userId) { setError(tr('admin.msg.no_user_id_short', 'No user ID.')); return; }
+        clearError();
+        setStatus(tr('admin.msg.tracearr_syncing', 'Syncing Tracearr history...'));
+        fetchJson('Plugins/AchievementBadges/users/' + userId + '/tracearr-sync', 'POST').then(function (result) {
+            if (result && result.Success === false) {
+                setStatus('');
+                setError(result.Message || tr('admin.msg.tracearr_failed', 'Tracearr sync failed.'));
+                return;
+            }
+            return reloadAll().then(function () {
+                // Zero is the expected answer on a second press, so say so
+                // rather than leaving it looking like a failure.
+                var n = (result && result.PlaysCredited) || 0;
+                setStatus(n > 0
+                    ? tr('admin.msg.tracearr_done', 'Tracearr sync complete!') + ' ' + n + ' ' + tr('admin.msg.tracearr_plays', 'plays credited.')
+                    : tr('admin.msg.tracearr_nothing', 'Tracearr sync complete. Nothing new to credit.'));
+            });
+        }).catch(function (err) {
+            setStatus('');
+            setError(tr('admin.msg.tracearr_failed', 'Tracearr sync failed.') + ' ' + (err && err.message ? err.message : String(err)));
         });
     });
 

--- a/Jellyfin.Plugin.AchievementBadges/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.AchievementBadges/PluginServiceRegistrator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.RateLimiting;
 using Jellyfin.Plugin.AchievementBadges.Api;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Jellyfin.Plugin.AchievementBadges.Services;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
@@ -33,6 +34,14 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<TimeWindowedRecomputeService>();
         serviceCollection.AddSingleton<PlaybackCompletionService>();
         serviceCollection.AddSingleton<WatchHistoryBackfillService>();
+        // [issue #45 button] Sidecar next to badges.json, same place the
+        // watch-carry store lives. Singleton because two instances would each
+        // hold half the record and neither would prevent double crediting.
+        serviceCollection.AddSingleton(provider => new TracearrCreditLedger(
+            System.IO.Path.Combine(
+                provider.GetRequiredService<MediaBrowser.Common.Configuration.IApplicationPaths>().PluginConfigurationsPath,
+                "achievementbadges",
+                "tracearr-credited.json")));
         serviceCollection.AddSingleton<LibraryCompletionService>();
         serviceCollection.AddSingleton<RecapService>();
         serviceCollection.AddSingleton<RecommendationService>();

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -29,6 +29,7 @@ public class AchievementBadgeService : IDisposable
     private readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = false };
     private readonly ILogger<AchievementBadgeService> _logger;
     private readonly IUserManager _userManager;
+    private readonly TracearrCreditLedger? _tracearrLedger;
     private readonly WebhookNotifier? _webhookNotifier;
     private readonly AuditLogService? _auditLog;
 
@@ -52,9 +53,11 @@ public class AchievementBadgeService : IDisposable
         ILogger<AchievementBadgeService> logger,
         PowerUpService? powerUps = null,
         ShopService? shop = null,
-        CustomBadgeService? customBadges = null)
+        CustomBadgeService? customBadges = null,
+        TracearrCreditLedger? tracearrLedger = null)
     {
         _logger = logger;
+        _tracearrLedger = tracearrLedger;
         _userManager = userManager;
         _webhookNotifier = webhookNotifier;
         _auditLog = auditLog;
@@ -1598,6 +1601,14 @@ public class AchievementBadgeService : IDisposable
             }
 
             _userProfiles[userId] = profile;
+
+            // [issue #45 button] The Tracearr ledger records which plays were
+            // already counted, so a standalone sync cannot count them twice.
+            // A reset wipes the counters those plays fed, so they genuinely
+            // need crediting again: keeping the ledger here would leave the
+            // user permanently missing them.
+            _tracearrLedger?.Forget(userId);
+
             Save();
             _logger.LogInformation("Reset badges for user {UserId}", userId);
             return profile.Badges.Select(CloneBadge).ToList();

--- a/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/TracearrClient.cs
@@ -225,6 +225,7 @@ public class TracearrClient
 
         return new TracearrPlay
         {
+            Id = ReadString(row, "id"),
             RatingKey = ratingKey,
             MediaType = ReadString(row, "media_type"),
             MediaTitle = ReadString(row, "media_title"),

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -31,6 +31,7 @@ public class WatchHistoryBackfillService
     private readonly IUserDataManager _userDataManager;
     private readonly AchievementBadgeService _achievementBadgeService;
     private readonly LibraryCompletionService _libraryCompletionService;
+    private readonly TracearrCreditLedger _tracearrLedger;
     private readonly ILogger<WatchHistoryBackfillService> _logger;
 
     public WatchHistoryBackfillService(
@@ -39,6 +40,7 @@ public class WatchHistoryBackfillService
         IUserDataManager userDataManager,
         AchievementBadgeService achievementBadgeService,
         LibraryCompletionService libraryCompletionService,
+        TracearrCreditLedger tracearrLedger,
         ILogger<WatchHistoryBackfillService> logger)
     {
         _libraryManager = libraryManager;
@@ -46,6 +48,7 @@ public class WatchHistoryBackfillService
         _userDataManager = userDataManager;
         _achievementBadgeService = achievementBadgeService;
         _libraryCompletionService = libraryCompletionService;
+        _tracearrLedger = tracearrLedger;
         _logger = logger;
     }
 
@@ -105,6 +108,86 @@ public class WatchHistoryBackfillService
     /// a rebuild must not fire a burst of notifications.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// [issue #45 button] Credits Tracearr plays without resetting or
+    /// replaying anything, for the standalone sync.
+    /// <para>
+    /// The in-scan pass is safe because the scan wipes the profile first. This
+    /// one writes onto live counters, so it leans entirely on the ledger to
+    /// avoid counting a play twice. Pressing the button repeatedly credits
+    /// nothing after the first time.
+    /// </para>
+    /// <para>
+    /// It still has to know which items the library can account for, since
+    /// that is what separates a first watch from a rewatch. Inside a scan that
+    /// set falls out of the replay; here it is rebuilt with the same IsPlayed
+    /// queries, which is the whole extra cost of running standalone.
+    /// </para>
+    /// </summary>
+    public object SyncTracearrForUser(string userId)
+    {
+        if (!Guid.TryParse(userId, out var userGuid))
+        {
+            return new { Success = false, Message = "Invalid user ID." };
+        }
+
+        var user = _userManager.GetUserById(userGuid);
+        if (user is null)
+        {
+            return new { Success = false, Message = "User not found." };
+        }
+
+        var config = Plugin.Instance?.Configuration;
+        if (!TracearrClient.IsConfigured(config?.TracearrUrl, config?.TracearrApiToken))
+        {
+            return new { Success = false, Message = "Tracearr is not configured." };
+        }
+
+        // Same gate as the scan: one sync per user at a time, so two clicks
+        // cannot interleave and read the ledger before either has written it.
+        var gate = _userGates.GetOrAdd(userGuid, static _ => new object());
+        lock (gate)
+        {
+            var normalised = userGuid.ToString("D");
+            var credited = RunTracearrPass(normalised, user.Username, PlayedItemIds(user));
+
+            return new
+            {
+                UserId = normalised,
+                Username = user.Username,
+                PlaysCredited = credited,
+                Success = true
+            };
+        }
+    }
+
+    /// <summary>
+    /// Item ids this user has played that the library can still prove, which
+    /// is what the in-scan pass gets for free from its own replay.
+    /// </summary>
+    private HashSet<string> PlayedItemIds(Jellyfin.Database.Implementations.Entities.User user)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var kind in new[] { BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Book })
+        {
+            var query = new InternalItemsQuery(user)
+            {
+                IsPlayed = true,
+                IncludeItemTypes = new[] { kind },
+                Recursive = true,
+                EnableTotalRecordCount = false
+            };
+
+            foreach (var item in _libraryManager.GetItemsResult(query).Items)
+            {
+                ids.Add(item.Id.ToString("D"));
+            }
+        }
+
+        return ids;
+    }
+
     private int RunTracearrPass(string userId, string username, HashSet<string> creditedItemIds)
     {
         var config = Plugin.Instance?.Configuration;
@@ -140,8 +223,10 @@ public class WatchHistoryBackfillService
                 .GetHistoryAsync(baseUri!, config.TracearrApiToken, accountId!, CancellationToken.None)
                 .GetAwaiter().GetResult();
 
-            foreach (var credit in TracearrCreditPlan.Build(plays, creditedItemIds))
+            var newlyCredited = new List<string>();
+            foreach (var credit in TracearrCreditPlan.Build(plays, creditedItemIds, _tracearrLedger.For(userId)))
             {
+                if (!string.IsNullOrWhiteSpace(credit.Play.Id)) newlyCredited.Add(credit.Play.Id!);
                 var play = credit.Play;
                 _achievementBadgeService.RecordPlayback(new PlaybackContext
                 {
@@ -161,6 +246,10 @@ public class WatchHistoryBackfillService
 
                 credited++;
             }
+
+            // Recorded after the fact: a play that failed to credit must not
+            // be remembered as credited, or it is lost for good.
+            _tracearrLedger.Remember(userId, newlyCredited);
 
             _logger.LogInformation(
                 "[AchievementBadges] Tracearr credited {Count} plays for {Username} that the library could not account for.",

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -149,6 +149,32 @@ public class WatchHistoryBackfillService
         lock (gate)
         {
             var normalised = userGuid.ToString("D");
+
+            // A user with no ledger at all has not been synced under a version
+            // that keeps one, but their counters may already include Tracearr
+            // credits from a scan that ran before the ledger existed. There is
+            // no way to tell which, so crediting would double every one of
+            // them. Measured on a live upgrade: RewatchCount 6 to 12.
+            //
+            // So the first sync adopts instead of crediting: it records what
+            // is currently creditable and counts nothing. A scan clears the
+            // ledger and rebuilds it honestly, which is the way to get those
+            // plays counted if they never were.
+            if (_tracearrLedger.For(normalised).Count == 0)
+            {
+                var adopted = AdoptWithoutCrediting(normalised, user);
+                return new
+                {
+                    UserId = normalised,
+                    Username = user.Username,
+                    PlaysCredited = 0,
+                    Adopted = adopted,
+                    Success = true,
+                    Message = "First sync for this user: " + adopted
+                        + " plays recorded as already counted, none credited. Run a watch history scan if they were never counted."
+                };
+            }
+
             var credited = RunTracearrPass(normalised, user.Username, PlayedItemIds(user));
 
             return new
@@ -156,8 +182,47 @@ public class WatchHistoryBackfillService
                 UserId = normalised,
                 Username = user.Username,
                 PlaysCredited = credited,
+                Adopted = 0,
                 Success = true
             };
+        }
+    }
+
+    /// <summary>
+    /// Records every play that would be creditable right now as already
+    /// counted, without crediting any of it. Used the first time a user is
+    /// synced, when their counters may already hold credits from before the
+    /// ledger existed and there is no way to tell which.
+    /// </summary>
+    private int AdoptWithoutCrediting(string userId, Jellyfin.Database.Implementations.Entities.User user)
+    {
+        var config = Plugin.Instance?.Configuration;
+        if (!TracearrClient.TryBuildBaseUri(config!.TracearrUrl, out var baseUri, out _)) return 0;
+
+        try
+        {
+            var client = new TracearrClient(_logger);
+            var accountId = client
+                .ResolveAccountIdAsync(baseUri!, config.TracearrApiToken, userId, CancellationToken.None)
+                .GetAwaiter().GetResult();
+            if (string.IsNullOrEmpty(accountId)) return 0;
+
+            var plays = client
+                .GetHistoryAsync(baseUri!, config.TracearrApiToken, accountId!, CancellationToken.None)
+                .GetAwaiter().GetResult();
+
+            var ids = TracearrCreditPlan.Build(plays, PlayedItemIds(user))
+                .Select(c => c.Play.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id!)
+                .ToList();
+
+            return _tracearrLedger.Remember(userId, ids);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[AchievementBadges] Tracearr adopt failed for {Username}.", user.Username);
+            return 0;
         }
     }
 


### PR DESCRIPTION
The separate Tracearr button from #77, built the way I described there.

## Why this is more than a route

The in-scan pass is safe because the scan resets the profile first: it credits onto counters that were just wiped. A button has nothing wiping anything, so an additive pass would credit every play again on each press. Rewatch counts double, totals inflate, and there is no way back except the reset that loses everything else.

So the button is backed by a record of what has already been counted. `TracearrCreditLedger` persists Tracearr's own play ids per user in a sidecar next to `badges.json`, written atomically, in the same shape as the watch carry store. The credit plan skips anything already in it, and **both paths write to the same record**, so the button and the scan cannot double up on each other either.

**Resetting a profile clears that user's ledger.** This is the part that makes it correct rather than merely safe against double clicks: a reset wipes the counters those plays fed, so they genuinely need crediting again, and keeping the record would leave the user permanently short.

## Two details the design forced

The ledger skip happens **after** the position check, not before. Removing a credited play from the list must not promote a later one to first watch, or a rewatch silently becomes a first viewing.

The endpoint returns the number of plays credited, and the button says "nothing new to credit" when it is zero. On a second press zero is the correct answer, and without saying so it reads like a failure.

## Cost of running standalone

It still has to know which items the library can account for, since that is what separates a first watch from a rewatch. Inside a scan that falls out of the replay; here it is rebuilt with three `IsPlayed` queries. That is the entire extra cost.

## Tests

`TracearrLedgerTests`, eight of them. The one that matters is `PressingTheButtonTwiceCreditsNothingTheSecondTime`. The rest cover a new play still being credited after an earlier sync and staying a rewatch, forget-on-reset, per-user isolation, GUID matching across hyphen and case, surviving a restart, honest reporting of what was new, and a corrupt ledger not stopping startup.

I removed the ledger check and confirmed two fail, rather than assuming they would. 187 of 187, Release build clean.

## What I have not done

The button is per user, using the picker already on that page. I did not add an all-users variant: it is easy, but the scan already covers that case and I would rather you tell me you want it than guess. Nor have I exercised the double press against a live server yet; the ledger behaviour is covered by tests, but if you would rather I run it here first and report numbers before you merge, say so and I will.
