### PR TITLE
feat(tracearr): log what the adopting first sync did

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -197,7 +197,11 @@ public class WatchHistoryBackfillService
     private int AdoptWithoutCrediting(string userId, Jellyfin.Database.Implementations.Entities.User user)
     {
         var config = Plugin.Instance?.Configuration;
-        if (!TracearrClient.TryBuildBaseUri(config!.TracearrUrl, out var baseUri, out _)) return 0;
+        if (!TracearrClient.TryBuildBaseUri(config!.TracearrUrl, out var baseUri, out var urlError))
+        {
+            _logger.LogWarning("[AchievementBadges] Tracearr not used for {Username}: {Error}", user.Username, urlError);
+            return 0;
+        }
 
         try
         {
@@ -205,7 +209,12 @@ public class WatchHistoryBackfillService
             var accountId = client
                 .ResolveAccountIdAsync(baseUri!, config.TracearrApiToken, userId, CancellationToken.None)
                 .GetAwaiter().GetResult();
-            if (string.IsNullOrEmpty(accountId)) return 0;
+
+            if (string.IsNullOrEmpty(accountId))
+            {
+                _logger.LogInformation("[AchievementBadges] No Tracearr account matches {Username}.", user.Username);
+                return 0;
+            }
 
             var plays = client
                 .GetHistoryAsync(baseUri!, config.TracearrApiToken, accountId!, CancellationToken.None)
@@ -217,7 +226,20 @@ public class WatchHistoryBackfillService
                 .Select(id => id!)
                 .ToList();
 
-            return _tracearrLedger.Remember(userId, ids);
+            var adopted = _tracearrLedger.Remember(userId, ids);
+
+            // The counterpart of the "credited N plays" line, and the reason
+            // this path needed one at all: adopting writes nothing to the
+            // profile, so without a log the first sync after an upgrade leaves
+            // no trace anywhere an admin would look. The only evidence was the
+            // ledger file appearing on disk.
+            _logger.LogInformation(
+                "[AchievementBadges] Tracearr recorded {Count} plays for {Username} as already counted, "
+                + "crediting none: first sync for this user, so their counters may already include these. "
+                + "A watch history scan clears the ledger and counts them honestly if they never were.",
+                adopted, user.Username);
+
+            return adopted;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
The log line you asked for. It turned into three, and I want to explain why rather than quietly widen the scope.

The adopt path was silent in **all three places its crediting counterpart speaks**:

| | crediting | adopting, before |
|---|---|---|
| bad Tracearr URL | `LogWarning` with the error | silent `return 0` |
| no matching account | `LogInformation` | silent `return 0` |
| outcome | `LogInformation` with the count | nothing |

Since adopting also writes nothing to the profile, that made the first sync after an upgrade invisible from every angle at once: no counter moved, no log line, no response left behind. When I verified it on my server the only evidence it had run was `tracearr-credited.json` appearing on disk. Restoring just the outcome line would have left the two silent bails, which are exactly the cases someone would be diagnosing.

The outcome line says what was recorded, that nothing was credited, why, and the way out:

```
[AchievementBadges] Tracearr recorded 53 plays for badpixel as already counted,
crediting none: first sync for this user, so their counters may already include
these. A watch history scan clears the ledger and counts them honestly if they
never were.
```

That last sentence is deliberate. Someone reading "recorded 53, credited 0" could reasonably conclude the feature is broken, and the log is the only place that can tell them it is not, and what to do if those plays really were never counted.

One file, 25 lines added. No behaviour change: same returns, same ledger writes, same response payload. Build clean, 188 of 188.
