### PR TITLE
feat(config): expose WatchCarryRetentionDays on the admin page

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -245,6 +245,39 @@ public class WatchCarryTests
     }
 
     [Fact]
+    public void ALongerWindowKeepsWhatTheDefaultWouldHaveDropped()
+    {
+        // The case this is for: a film watched a few nights a month, where two
+        // sittings sit more than a week apart. Under the default the first
+        // sitting expires before the second arrives, the running total starts
+        // from zero again, and the finished film never reaches the credit
+        // threshold. Nothing in the log says the earlier time was discarded.
+        var sitting = Seconds(2400);
+        var elevenDaysLater = Now.AddDays(11);
+
+        var byDefault = new WatchCarryStore(TimeSpan.FromDays(7));
+        byDefault.Remember(User, Item, sitting, Now);
+
+        var configured = new WatchCarryStore(TimeSpan.FromDays(30));
+        configured.Remember(User, Item, sitting, Now);
+
+        Assert.Equal(0, byDefault.Peek(User, Item, elevenDaysLater));
+        Assert.Equal(sitting, configured.Peek(User, Item, elevenDaysLater));
+    }
+
+    [Fact]
+    public void ZeroDaysTurnsCarryingOff_RatherThanMeaningUnlimited()
+    {
+        // Zero has to be a real choice, because the admin page now offers it.
+        // It must read as "do not carry", never as an empty window that keeps
+        // everything forever.
+        var store = new WatchCarryStore(TimeSpan.Zero);
+        store.Remember(User, Item, Seconds(2400), Now);
+
+        Assert.Equal(0, store.Peek(User, Item, Now.AddSeconds(1)));
+    }
+
+    [Fact]
     public void UnreadableCarryFile_StartsEmptyInsteadOfThrowing()
     {
         var path = TempFile();

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -2460,6 +2460,7 @@ public class AchievementBadgesController : ControllerBase
             ForceSpoilerMode = c?.ForceSpoilerMode ?? false,
             ForceExtremeSpoilerMode = c?.ForceExtremeSpoilerMode ?? false,
             MaxEquippedBadges = c?.MaxEquippedBadges ?? 5,
+            WatchCarryRetentionDays = c?.WatchCarryRetentionDays ?? 7,
             RestrictBadgeVisibility = c?.RestrictBadgeVisibility ?? false,
             DisabledBadgeCategories = c?.DisabledBadgeCategories ?? new List<string>(),
             WelcomeMessage = c?.WelcomeMessage ?? "",
@@ -2490,6 +2491,14 @@ public class AchievementBadgesController : ControllerBase
         public bool ForceSpoilerMode { get; set; } = false;
         public bool ForceExtremeSpoilerMode { get; set; } = false;
         public int MaxEquippedBadges { get; set; } = 5;
+
+        /// <summary>
+        /// Nullable on purpose. A non-nullable default would let any caller
+        /// that omits the field reset a configured retention back to 7 days,
+        /// silently discarding partial viewings the admin meant to keep.
+        /// </summary>
+        public int? WatchCarryRetentionDays { get; set; }
+
         public bool RestrictBadgeVisibility { get; set; } = false;
         public List<string> DisabledBadgeCategories { get; set; } = new();
         public string WelcomeMessage { get; set; } = "";
@@ -2526,6 +2535,15 @@ public class AchievementBadgesController : ControllerBase
         config.ForceSpoilerMode = request.ForceSpoilerMode;
         config.ForceExtremeSpoilerMode = request.ForceExtremeSpoilerMode;
         config.MaxEquippedBadges = Math.Clamp(request.MaxEquippedBadges, 1, 10);
+
+        // Omitted means "leave it alone", so a partial body cannot quietly
+        // shorten the window and throw away viewings already part-watched.
+        // Zero is a real choice: it turns carrying off.
+        if (request.WatchCarryRetentionDays is int carryDays)
+        {
+            config.WatchCarryRetentionDays = Math.Clamp(carryDays, 0, 365);
+        }
+
         config.RestrictBadgeVisibility = request.RestrictBadgeVisibility;
         config.DisabledBadgeCategories = request.DisabledBadgeCategories ?? new();
         config.WelcomeMessage = request.WelcomeMessage ?? "";

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -1948,6 +1948,10 @@ font-size:0.88em;
                         <label style="display:flex; align-items:center; gap:0.5em; margin-bottom:0.75em;">
                             <input type="checkbox" id="abFcRestrictBadgeVisibility"> <span data-i18n="admin.fc.restrict_visibility">Restrict badge visibility (users only see their own)</span>
                         </label>
+                        <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.fc.watch_carry_days">Remember partial viewings for (days):</span><br>
+                            <input type="number" id="abFcWatchCarryRetentionDays" value="7" min="0" max="365" style="width:80px; padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
+                            <div style="opacity:0.7; font-size:0.9em; margin-top:0.35em;" data-i18n="admin.fc.watch_carry_days_hint">How long an unfinished viewing is kept so a later sitting of the same item adds to it instead of starting from zero. A gap longer than this drops what was already watched. Raise it for viewers who finish a film across several weeks; 0 disables carrying entirely.</div>
+                        </label>
                         <label style="display:block; margin-bottom:0.75em;"><span data-i18n="admin.fc.disabled_categories">Disabled badge categories (comma-separated):</span><br>
                             <input type="text" id="abFcDisabledBadgeCategories" placeholder="e.g. Challenge, Custom" data-i18n-placeholder="admin.fc.disabled_categories_placeholder" style="width:100%; padding:0.5em; background:rgba(0,0,0,0.3); color:inherit; border:1px solid rgba(255,255,255,0.15); border-radius:4px;">
                         </label>
@@ -4196,6 +4200,9 @@ font-size:0.88em;
             document.getElementById('abFcForceSpoilerMode').checked = !!c.ForceSpoilerMode;
             document.getElementById('abFcForceExtremeSpoilerMode').checked = !!c.ForceExtremeSpoilerMode;
             document.getElementById('abFcMaxEquippedBadges').value = c.MaxEquippedBadges || 5;
+            // Not `|| 7`: zero is a valid setting that turns carrying off.
+            var carryEl = document.getElementById('abFcWatchCarryRetentionDays');
+            if (carryEl) carryEl.value = (typeof c.WatchCarryRetentionDays === 'number') ? c.WatchCarryRetentionDays : 7;
             document.getElementById('abFcRestrictBadgeVisibility').checked = !!c.RestrictBadgeVisibility;
             document.getElementById('abFcDisabledBadgeCategories').value = (c.DisabledBadgeCategories || []).join(', ');
             document.getElementById('abFcWelcomeMessage').value = c.WelcomeMessage || '';
@@ -4260,6 +4267,13 @@ font-size:0.88em;
         if (maxBadges < 1) maxBadges = 1;
         if (maxBadges > 10) maxBadges = 10;
 
+        // Sent as null when the field is absent or unparseable, which the
+        // server reads as "keep the current value" rather than as zero.
+        var carryEl = document.getElementById('abFcWatchCarryRetentionDays');
+        var carryDays = carryEl ? parseInt(carryEl.value, 10) : NaN;
+        if (isNaN(carryDays)) carryDays = null;
+        else carryDays = Math.min(365, Math.max(0, carryDays));
+
         fetchJson('Plugins/AchievementBadges/admin/feature-config', 'POST', {
             LeaderboardEnabled: document.getElementById('abFcLeaderboardEnabled').checked,
             CompareEnabled: document.getElementById('abFcCompareEnabled').checked,
@@ -4270,6 +4284,7 @@ font-size:0.88em;
             ForceSpoilerMode: document.getElementById('abFcForceSpoilerMode').checked,
             ForceExtremeSpoilerMode: document.getElementById('abFcForceExtremeSpoilerMode').checked,
             MaxEquippedBadges: maxBadges,
+            WatchCarryRetentionDays: carryDays,
             RestrictBadgeVisibility: document.getElementById('abFcRestrictBadgeVisibility').checked,
             DisabledBadgeCategories: categories,
             WelcomeMessage: document.getElementById('abFcWelcomeMessage').value || '',


### PR DESCRIPTION
Closes #86.

Worth reading the correction on that issue before this: I opened it believing the retention window had cost a viewer a film, then proved myself wrong. The real cause was a media file replacement orphaning the carry, which is a separate bug.

So this PR is narrower than the issue title suggests. The setting already worked and `WatchCarryStore` already honoured it. The only thing missing was a way to change it without hand-editing `Jellyfin.Plugin.AchievementBadges.xml`, which is what I ended up doing on my own server before deciding that was not a reasonable thing to ask of anyone. That argument stands on its own; it just is not the emergency I first thought it was.

Field goes next to **Max equipped badges** in Feature Config, with a hint explaining what a gap longer than the window costs.

## One decision worth your eyes

The request field is `int?`, not `int`:

```csharp
public int? WatchCarryRetentionDays { get; set; }
```

```csharp
if (request.WatchCarryRetentionDays is int carryDays)
{
    config.WatchCarryRetentionDays = Math.Clamp(carryDays, 0, 365);
}
```

A non-nullable `int` with a default of 7 would mean any POST that omits the field resets a configured retention back to the default. The page saves the whole feature-config object at once, so a browser holding an older cached `index.html` would do exactly that, and for this setting the cost is not cosmetic: shortening the window discards viewings already part-watched, silently, with nothing in the log. Omitted now reads as "leave it alone", which is how `AudiobookCounting` already behaves in the same handler.

Zero is kept as a real value rather than folded into the default, both server side and in the JS reader, since it is the way to turn carrying off. `|| 7` in the loader would have quietly made zero unreachable.

Range is 0 to 365, clamped on both sides.

## Tests

Two, on the store rather than the plumbing, because that is where the behaviour lives:

- a 30 day window still holds a sitting 11 days later, where the 7 day default returns zero
- zero means do not carry, not an empty window that keeps everything forever

Build clean, 190 of 190.

## Not in this PR

I did not touch the default. Raising it costs retention for everyone to help a minority, and once the field is reachable the people affected can raise it themselves. Happy to change it if you would rather, but I have no data to argue for a particular number and did not want to guess in a PR.
