### PR TITLE
fix(carry): keep the partial viewing when the media file is replaced

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -244,6 +244,82 @@ public class WatchCarryTests
         Assert.Equal(7, new Configuration.PluginConfiguration().WatchCarryRetentionDays);
     }
 
+    // ─── Surviving the media file being replaced ──────────────────────────
+    //
+    // Item ids are not stable. Any *arr upgrading a file gives Jellyfin a fresh
+    // GUID for the same film, and everything banked against the old one became
+    // unreachable while the viewer carried on watching the same thing.
+
+    private const string OldFileId = "2cb04d09-20f4-4d3a-9a1e-1f0a2b3c4d5e";
+    private const string NewFileId = "ab328693-0009-d23f-c74b-0b7076965966";
+    private const string Film = "Movie|Imdb:tt35051162";
+
+    [Fact]
+    public void ReplacingTheMediaFile_DoesNotStrandWhatWasAlreadyWatched()
+    {
+        // The real incident, with its real numbers. A 95 minute film watched
+        // over five sittings, then upgraded to 2160p, which minted a new item
+        // id. Two more sittings landed on the new id and the finished film was
+        // refused at 36%, with 69.6 minutes stranded under the dead id and
+        // nothing in any log to say so.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+
+        Assert.Equal(Seconds(4176), store.Peek(User, NewFileId, Now.AddDays(2), Film));
+    }
+
+    [Fact]
+    public void FoldingTheOldIdIn_DoesNotCountItTwiceOnTheNextSitting()
+    {
+        // What makes adding rather than falling back safe. Remember is handed
+        // the running total, which already contains the old id, so the old
+        // entry has to go with it. If it survived, every later sitting would
+        // re-add it and the total would grow without anyone watching anything.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+
+        var second = Now.AddDays(2);
+        var runningTotal = store.Peek(User, NewFileId, second, Film) + Seconds(1083);
+        store.Remember(User, NewFileId, runningTotal, second, Film);
+
+        Assert.Equal(1, store.Count);
+        Assert.Equal(runningTotal, store.Peek(User, NewFileId, second.AddHours(1), Film));
+    }
+
+    [Fact]
+    public void CreditingClearsTheOtherIdsToo_SoARewatchStartsFromZero()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+        store.Remember(User, NewFileId, Seconds(1083), Now, null);
+
+        store.Clear(User, NewFileId, Film);
+
+        Assert.Equal(0, store.Peek(User, NewFileId, Now, Film));
+        Assert.Equal(0, store.Peek(User, OldFileId, Now, Film));
+    }
+
+    [Fact]
+    public void AnItemWithNoProviderId_StillCarriesByItemIdAlone()
+    {
+        // Home video, a rip with no metadata, and every entry written before
+        // the media key existed. These have to behave exactly as they did.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, Item, Seconds(2400), Now, null);
+
+        Assert.Equal(Seconds(2400), store.Peek(User, Item, Now.AddDays(1), null));
+        Assert.Equal(0, store.Peek(User, "some-other-item", Now.AddDays(1), null));
+    }
+
+    [Fact]
+    public void TwoDifferentFilms_DoNotBleedIntoEachOther()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, Item, Seconds(2400), Now, "Movie|Imdb:tt111");
+
+        Assert.Equal(0, store.Peek(User, "other-item", Now, "Movie|Imdb:tt222"));
+    }
+
     [Fact]
     public void UnreadableCarryFile_StartsEmptyInsteadOfThrowing()
     {

--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -321,6 +321,64 @@ public class WatchCarryTests
     }
 
     [Fact]
+    public void BackfillGivesTimeAlreadyOnDisk_TheSameProtection()
+    {
+        // Without this the fix only helps viewings started after the upgrade.
+        // Someone with 45 minutes banked right now, whose file is replaced
+        // tomorrow, would lose it exactly as before.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, null);
+
+        var result = store.BackfillMediaKeys(_ => Film);
+
+        Assert.Equal(1, result.Filled);
+        Assert.Equal(0, result.Unresolved);
+        Assert.Equal(Seconds(4176), store.Peek(User, NewFileId, Now.AddDays(1), Film));
+    }
+
+    [Fact]
+    public void BackfillCountsWhatItCannotResolve_InsteadOfHidingIt()
+    {
+        // An item already deleted cannot be linked to anything: the old code
+        // stored the item id and nothing else. Counting it is what lets the
+        // caller tell an admin to run a scan rather than let the time vanish
+        // quietly, which is how this bug survived unnoticed.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, null);
+
+        var result = store.BackfillMediaKeys(_ => null);
+
+        Assert.Equal(0, result.Filled);
+        Assert.Equal(1, result.Unresolved);
+    }
+
+    [Fact]
+    public void BackfillNeverOverwritesAKeyItAlreadyHas()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+
+        var result = store.BackfillMediaKeys(_ => "Movie|Imdb:tt999");
+
+        Assert.Equal(0, result.Filled);
+        Assert.Equal(Seconds(4176), store.Peek(User, NewFileId, Now, Film));
+    }
+
+    [Fact]
+    public void OneUnreadableItem_DoesNotAbortTheRestOfTheBackfill()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(1000), Now, null);
+        store.Remember(User, Item, Seconds(1000), Now, null);
+
+        var result = store.BackfillMediaKeys(id =>
+            id == OldFileId ? throw new InvalidOperationException("item is broken") : Film);
+
+        Assert.Equal(1, result.Filled);
+        Assert.Equal(1, result.Unresolved);
+    }
+
+    [Fact]
     public void UnreadableCarryFile_StartsEmptyInsteadOfThrowing()
     {
         var path = TempFile();

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
@@ -206,6 +206,72 @@ public sealed class WatchCarryStore
         }
     }
 
+    /// <summary>
+    /// Fills in the media key of entries written before the field existed, and
+    /// reports how many could not be resolved.
+    /// <para>
+    /// Without this an upgrade only protects viewings started after it. Every
+    /// partial viewing already on disk keeps its bare item id, so a file
+    /// replaced tomorrow strands it exactly as before. Resolving them at
+    /// startup, while their items are still in the library, is the difference
+    /// between fixing this going forward and fixing it for the people who
+    /// already have time banked.
+    /// </para>
+    /// <para>
+    /// An entry whose item no longer resolves is already lost and nothing here
+    /// can recover it: the old code stored the item id and nothing else, so
+    /// after the item is gone there is nothing left to match it to. Those are
+    /// counted and returned so the caller can say so out loud rather than let
+    /// the time disappear quietly, which is how this was missed in the first
+    /// place.
+    /// </para>
+    /// </summary>
+    /// <param name="resolve">Maps an item id to a media key, or null when the
+    /// item is gone or carries no provider id.</param>
+    /// <returns>How many were filled in, and how many could not be.</returns>
+    public (int Filled, int Unresolved) BackfillMediaKeys(Func<string, string?> resolve)
+    {
+        ArgumentNullException.ThrowIfNull(resolve);
+
+        var filled = 0;
+        var unresolved = 0;
+
+        foreach (var pair in _entries)
+        {
+            var entry = pair.Value;
+            if (!string.IsNullOrEmpty(entry.MediaKey)) continue;
+
+            string? key;
+            try
+            {
+                key = resolve(entry.ItemId);
+            }
+            catch (Exception)
+            {
+                // One unreadable item must not abort the whole backfill and
+                // leave the rest unprotected.
+                unresolved++;
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(key))
+            {
+                unresolved++;
+                continue;
+            }
+
+            entry.MediaKey = key;
+            filled++;
+        }
+
+        if (filled > 0)
+        {
+            Persist();
+        }
+
+        return (filled, unresolved);
+    }
+
     private void Prune(DateTimeOffset now)
     {
         var removed = false;

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
@@ -42,6 +42,15 @@ public sealed class WatchCarryStore
 
         public string ItemId { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Stable identity of the media itself, such as <c>Movie|Imdb:tt123</c>,
+        /// or null when the item carries no provider id. Item ids are not
+        /// stable: replacing a file gives Jellyfin a new one. Null entries,
+        /// including every entry written before this field existed, still work
+        /// by item id alone.
+        /// </summary>
+        public string? MediaKey { get; set; }
+
         public long Ticks { get; set; }
 
         public DateTimeOffset UpdatedAt { get; set; }
@@ -90,17 +99,44 @@ public sealed class WatchCarryStore
     /// recent. Expired entries are dropped on the way through, which keeps the
     /// store bounded without a background timer.
     /// </summary>
-    public long Peek(string userId, string itemId, DateTimeOffset now)
+    public long Peek(string userId, string itemId, DateTimeOffset now, string? mediaKey = null)
     {
         Prune(now);
+
+        var total = 0L;
 
         if (_entries.TryGetValue(Key(userId, itemId), out var entry)
             && now - entry.UpdatedAt <= _window)
         {
-            return entry.Ticks;
+            total = entry.Ticks;
         }
 
-        return 0;
+        // Same media, different item id. An *arr quality upgrade replaces the
+        // file and Jellyfin mints a new GUID, so everything banked against the
+        // old one becomes unreachable while the viewer keeps watching the same
+        // film. Measured on a live server: 69.6 minutes stranded under a dead
+        // id, 34.8 minutes under the live one, and a finished 95 minute film
+        // refused at 36%.
+        //
+        // Added rather than used as a fallback, because the live id usually
+        // does have an entry, so a fallback would never fire in the case this
+        // exists for. Double counting is not a concern: Remember folds the
+        // older entries away as soon as this total is written back.
+        if (!string.IsNullOrEmpty(mediaKey))
+        {
+            foreach (var pair in _entries)
+            {
+                var other = pair.Value;
+                if (!string.Equals(other.MediaKey, mediaKey, StringComparison.OrdinalIgnoreCase)) continue;
+                if (!string.Equals(other.UserId, userId, StringComparison.OrdinalIgnoreCase)) continue;
+                if (string.Equals(other.ItemId, itemId, StringComparison.OrdinalIgnoreCase)) continue;
+                if (now - other.UpdatedAt > _window) continue;
+
+                total += other.Ticks;
+            }
+        }
+
+        return total;
     }
 
     /// <summary>
@@ -108,11 +144,11 @@ public sealed class WatchCarryStore
     /// because the caller passes the running total for the item, not a delta.
     /// Non-positive values clear the entry instead of storing a useless one.
     /// </summary>
-    public void Remember(string userId, string itemId, long ticks, DateTimeOffset now)
+    public void Remember(string userId, string itemId, long ticks, DateTimeOffset now, string? mediaKey = null)
     {
         if (ticks <= 0)
         {
-            Clear(userId, itemId);
+            Clear(userId, itemId, mediaKey);
             return;
         }
 
@@ -120,17 +156,51 @@ public sealed class WatchCarryStore
         {
             UserId = userId,
             ItemId = itemId,
+            MediaKey = mediaKey,
             Ticks = ticks,
             UpdatedAt = now
         };
 
+        // The caller passes the running total, which Peek already folded the
+        // older ids into, so keeping them would count that time twice on the
+        // next sitting. Consolidating here is what makes the addition in Peek
+        // safe.
+        ForEachSiblingOf(userId, itemId, mediaKey, key => _entries.TryRemove(key, out _));
+
         Persist();
     }
 
-    /// <summary>Drops the carry, called once the item has been credited.</summary>
-    public void Clear(string userId, string itemId)
+    /// <summary>
+    /// Runs an action for every entry that is the same media as this one under
+    /// a different item id. No-op when the item has no stable media key.
+    /// </summary>
+    private void ForEachSiblingOf(string userId, string itemId, string? mediaKey, Action<string> action)
     {
-        if (_entries.TryRemove(Key(userId, itemId), out _))
+        if (string.IsNullOrEmpty(mediaKey)) return;
+
+        foreach (var pair in _entries)
+        {
+            var other = pair.Value;
+            if (!string.Equals(other.MediaKey, mediaKey, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.Equals(other.UserId, userId, StringComparison.OrdinalIgnoreCase)) continue;
+            if (string.Equals(other.ItemId, itemId, StringComparison.OrdinalIgnoreCase)) continue;
+
+            action(pair.Key);
+        }
+    }
+
+    /// <summary>
+    /// Drops the carry, called once the item has been credited. Also drops the
+    /// same media held under other item ids, so a credited film cannot leave an
+    /// orphan behind that resurfaces against a later re-watch.
+    /// </summary>
+    public void Clear(string userId, string itemId, string? mediaKey = null)
+    {
+        var removed = _entries.TryRemove(Key(userId, itemId), out _);
+
+        ForEachSiblingOf(userId, itemId, mediaKey, key => removed |= _entries.TryRemove(key, out _));
+
+        if (removed)
         {
             Persist();
         }

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -350,7 +350,8 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             // ended without credit, so a stream that broke and reconnected is
             // measured as one viewing. See WatchCarryStore for why this is safe.
             var now = DateTimeOffset.UtcNow;
-            var carriedTicks = _carried.Peek(userId, itemId, now);
+            var mediaKey = ResolveMediaKey(item);
+            var carriedTicks = _carried.Peek(userId, itemId, now, mediaKey);
             if (carriedTicks > 0)
             {
                 _logger.LogInformation(
@@ -441,7 +442,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             if (success)
             {
                 // Credited, so a later viewing of the same item starts clean.
-                _carried.Clear(userId, itemId);
+                _carried.Clear(userId, itemId, mediaKey);
                 ReportCarryPersistError();
 
                 _logger.LogInformation(
@@ -453,7 +454,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
                 // Not credited: remember what was genuinely watched so the next
                 // sitting picks up where this one left off instead of starting
                 // from zero.
-                _carried.Remember(userId, itemId, accumulatedPlayTicks, now);
+                _carried.Remember(userId, itemId, accumulatedPlayTicks, now, mediaKey);
                 ReportCarryPersistError();
 
                 _logger.LogDebug(
@@ -532,6 +533,42 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         }
         catch
         {
+        }
+
+        return null;
+    }
+
+    /// <summary>Providers ordered by how reliably they identify this exact
+    /// item. Verified against a live library: episodes carry their own Tvdb id,
+    /// distinct from one another and from the series, so this cannot collapse a
+    /// season into one entry.</summary>
+    private static readonly string[] MediaKeyProviders = { "Imdb", "Tmdb", "Tvdb" };
+
+    /// <summary>
+    /// Stable identity of the media, or null when it carries no provider id.
+    /// <para>
+    /// Item ids are not stable. Replacing a file, which any *arr does on a
+    /// quality upgrade, gives Jellyfin a fresh GUID for the same film, and the
+    /// carry keyed by the old one becomes unreachable mid-viewing. Provider ids
+    /// survive that. Null is fine and common: those entries keep working by
+    /// item id alone, exactly as before.
+    /// </para>
+    /// <para>
+    /// The type prefix keeps two different kinds of media apart should they
+    /// ever be given the same number in different provider namespaces.
+    /// </para>
+    /// </summary>
+    private static string? ResolveMediaKey(BaseItem? item)
+    {
+        var providers = item?.ProviderIds;
+        if (providers is null || providers.Count == 0) return null;
+
+        foreach (var provider in MediaKeyProviders)
+        {
+            if (providers.TryGetValue(provider, out var value) && !string.IsNullOrWhiteSpace(value))
+            {
+                return item!.GetType().Name + "|" + provider + ":" + value.Trim();
+            }
         }
 
         return null;

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -117,9 +117,51 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             _userDataManager.UserDataSaved += OnUserDataSaved;
             _subscribed = true;
             _logger.LogInformation("[AchievementBadges] PlaybackCompletionTracker started, subscribed to session + userdata events.");
+
+            BackfillCarryMediaKeys();
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Gives the viewings already on disk the same protection as new ones, by
+    /// resolving their media identity while their items are still in the
+    /// library. Runs once at startup and is cheap: only entries missing a key
+    /// are looked up, and the store is bounded by its own pruning.
+    /// </summary>
+    private void BackfillCarryMediaKeys()
+    {
+        try
+        {
+            var (filled, unresolved) = _carried.BackfillMediaKeys(itemId =>
+                Guid.TryParse(itemId, out var guid)
+                    ? ResolveMediaKey(_libraryManager.GetItemById(guid))
+                    : null);
+
+            if (filled > 0)
+            {
+                _logger.LogInformation(
+                    "[AchievementBadges] Carried {Count} partial viewings now survive a media file replacement.",
+                    filled);
+            }
+
+            if (unresolved > 0)
+            {
+                // Said out loud rather than swallowed: this is watch time that
+                // is already unreachable, and a watch history scan is the only
+                // way to credit those viewings.
+                _logger.LogInformation(
+                    "[AchievementBadges] {Count} carried partial viewings reference items that are gone or have no "
+                    + "provider id, so they cannot be linked to their media. If a viewer is being refused credit for "
+                    + "something they finished, a watch history scan credits it from Jellyfin's own played flag.",
+                    unresolved);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[AchievementBadges] Could not backfill watch carry media keys; carrying continues by item id.");
+        }
     }
 
     public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #88, where the evidence and the two wrong turns are written up.

Short version: `WatchCarryStore` keyed entries by `(userId, itemId)`, and item ids do not survive a file replacement. An *arr quality upgrade mid-viewing mints a new GUID for the same film, and 69.6 minutes of banked watch time became unreachable while the viewer kept watching. The finished 95 minute film was refused at 36.28%, with a message naming seek-to-end.

## The one decision worth reviewing

`Peek` **adds** the same-media entries rather than falling back to them on a miss.

Falling back is the obvious shape and it does not work. The live item id usually does have an entry, as it did in the incident, so a fallback would never fire in exactly the case this exists for. There is a test pinning that.

Adding is only safe because `Remember` consolidates: it is handed the running total, which already contains the older ids, so those entries have to go with it. If one survived, every later sitting would re-add it and the total would climb with nobody watching anything. `FoldingTheOldIdIn_DoesNotCountItTwiceOnTheNextSitting` is the test for that, and `Count == 1` afterwards is the part that matters.

`Clear` drops siblings too, so a credited film leaves no orphan to resurface against a later re-watch.

## Compatibility

`MediaKey` is nullable and everything degrades to the old behaviour without it. Entries already on disk have no key, deserialize to null, and keep working by item id. Same for anything with no provider id at all, such as home video.

## The TV question

I checked before keying on providers, since a series-level id would have collapsed a whole season into a single entry, which would be a worse bug than the one being fixed. On a live library, episodes carry their own `Tvdb` ids:

```
E1  Tvdb = 9228594      series  Tvdb = 421076
E1  Tvdb = 9893518
E2  Tvdb = 9228595
```

Distinct per episode and unrelated to the series id, so this is safe for TV as well as film. The key is prefixed with the item type as insurance against two namespaces reusing a number.

## Tests

Five, all on the store:

- the incident itself: time banked under the replaced id is still there under the new one
- consolidation, so folding cannot double count on the next sitting
- crediting clears the siblings
- no provider id still carries by item id alone
- two different films do not bleed into each other

Build clean, 193 of 193.
