### PR TITLE
fix(carry): the watch history scan now drops the carry of what it credits

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/LibraryCompletionWiringTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/LibraryCompletionWiringTests.cs
@@ -32,6 +32,27 @@ public class LibraryCompletionWiringTests
     }
 
     [Fact]
+    public void TheBackfillCanReachTheWatchCarryStore()
+    {
+        // Same shape of defect, different store. The carry was owned privately
+        // by PlaybackCompletionTracker, so the scan could not drop the carry of
+        // items it credited. Those minutes stayed banked and a later partial
+        // rewatch reached the 80% gate on time already spent: measured live, an
+        // item sat at 72.3% carried after being credited.
+        //
+        // Being straight about what this proves: it pins the dependency, not
+        // the call. Exercising the call needs the whole backfill stack, and the
+        // evidence for it is the live run recorded in the PR, not this test.
+        var constructor = typeof(WatchHistoryBackfillService)
+            .GetConstructors()
+            .Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(Helpers.WatchCarryStore));
+    }
+
+    [Fact]
     public void TheLibraryBadgesStillReadTheMetricTheyAlwaysDid()
     {
         // Guards the other end: wiring the producer is pointless if the badges

--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -244,6 +244,82 @@ public class WatchCarryTests
         Assert.Equal(7, new Configuration.PluginConfiguration().WatchCarryRetentionDays);
     }
 
+    // ─── Surviving the media file being replaced ──────────────────────────
+    //
+    // Item ids are not stable. Any *arr upgrading a file gives Jellyfin a fresh
+    // GUID for the same film, and everything banked against the old one became
+    // unreachable while the viewer carried on watching the same thing.
+
+    private const string OldFileId = "2cb04d09-20f4-4d3a-9a1e-1f0a2b3c4d5e";
+    private const string NewFileId = "ab328693-0009-d23f-c74b-0b7076965966";
+    private const string Film = "Movie|Imdb:tt35051162";
+
+    [Fact]
+    public void ReplacingTheMediaFile_DoesNotStrandWhatWasAlreadyWatched()
+    {
+        // The real incident, with its real numbers. A 95 minute film watched
+        // over five sittings, then upgraded to 2160p, which minted a new item
+        // id. Two more sittings landed on the new id and the finished film was
+        // refused at 36%, with 69.6 minutes stranded under the dead id and
+        // nothing in any log to say so.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+
+        Assert.Equal(Seconds(4176), store.Peek(User, NewFileId, Now.AddDays(2), Film));
+    }
+
+    [Fact]
+    public void FoldingTheOldIdIn_DoesNotCountItTwiceOnTheNextSitting()
+    {
+        // What makes adding rather than falling back safe. Remember is handed
+        // the running total, which already contains the old id, so the old
+        // entry has to go with it. If it survived, every later sitting would
+        // re-add it and the total would grow without anyone watching anything.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+
+        var second = Now.AddDays(2);
+        var runningTotal = store.Peek(User, NewFileId, second, Film) + Seconds(1083);
+        store.Remember(User, NewFileId, runningTotal, second, Film);
+
+        Assert.Equal(1, store.Count);
+        Assert.Equal(runningTotal, store.Peek(User, NewFileId, second.AddHours(1), Film));
+    }
+
+    [Fact]
+    public void CreditingClearsTheOtherIdsToo_SoARewatchStartsFromZero()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+        store.Remember(User, NewFileId, Seconds(1083), Now, null);
+
+        store.Clear(User, NewFileId, Film);
+
+        Assert.Equal(0, store.Peek(User, NewFileId, Now, Film));
+        Assert.Equal(0, store.Peek(User, OldFileId, Now, Film));
+    }
+
+    [Fact]
+    public void AnItemWithNoProviderId_StillCarriesByItemIdAlone()
+    {
+        // Home video, a rip with no metadata, and every entry written before
+        // the media key existed. These have to behave exactly as they did.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, Item, Seconds(2400), Now, null);
+
+        Assert.Equal(Seconds(2400), store.Peek(User, Item, Now.AddDays(1), null));
+        Assert.Equal(0, store.Peek(User, "some-other-item", Now.AddDays(1), null));
+    }
+
+    [Fact]
+    public void TwoDifferentFilms_DoNotBleedIntoEachOther()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, Item, Seconds(2400), Now, "Movie|Imdb:tt111");
+
+        Assert.Equal(0, store.Peek(User, "other-item", Now, "Movie|Imdb:tt222"));
+    }
+
     [Fact]
     public void UnreadableCarryFile_StartsEmptyInsteadOfThrowing()
     {

--- a/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/WatchCarryTests.cs
@@ -321,6 +321,64 @@ public class WatchCarryTests
     }
 
     [Fact]
+    public void BackfillGivesTimeAlreadyOnDisk_TheSameProtection()
+    {
+        // Without this the fix only helps viewings started after the upgrade.
+        // Someone with 45 minutes banked right now, whose file is replaced
+        // tomorrow, would lose it exactly as before.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, null);
+
+        var result = store.BackfillMediaKeys(_ => Film);
+
+        Assert.Equal(1, result.Filled);
+        Assert.Equal(0, result.Unresolved);
+        Assert.Equal(Seconds(4176), store.Peek(User, NewFileId, Now.AddDays(1), Film));
+    }
+
+    [Fact]
+    public void BackfillCountsWhatItCannotResolve_InsteadOfHidingIt()
+    {
+        // An item already deleted cannot be linked to anything: the old code
+        // stored the item id and nothing else. Counting it is what lets the
+        // caller tell an admin to run a scan rather than let the time vanish
+        // quietly, which is how this bug survived unnoticed.
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, null);
+
+        var result = store.BackfillMediaKeys(_ => null);
+
+        Assert.Equal(0, result.Filled);
+        Assert.Equal(1, result.Unresolved);
+    }
+
+    [Fact]
+    public void BackfillNeverOverwritesAKeyItAlreadyHas()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(4176), Now, Film);
+
+        var result = store.BackfillMediaKeys(_ => "Movie|Imdb:tt999");
+
+        Assert.Equal(0, result.Filled);
+        Assert.Equal(Seconds(4176), store.Peek(User, NewFileId, Now, Film));
+    }
+
+    [Fact]
+    public void OneUnreadableItem_DoesNotAbortTheRestOfTheBackfill()
+    {
+        var store = new WatchCarryStore(TimeSpan.FromDays(7));
+        store.Remember(User, OldFileId, Seconds(1000), Now, null);
+        store.Remember(User, Item, Seconds(1000), Now, null);
+
+        var result = store.BackfillMediaKeys(id =>
+            id == OldFileId ? throw new InvalidOperationException("item is broken") : Film);
+
+        Assert.Equal(1, result.Filled);
+        Assert.Equal(1, result.Unresolved);
+    }
+
+    [Fact]
     public void UnreadableCarryFile_StartsEmptyInsteadOfThrowing()
     {
         var path = TempFile();

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/MediaIdentity.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/MediaIdentity.cs
@@ -1,0 +1,44 @@
+using MediaBrowser.Controller.Entities;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// Identity of the media itself, as opposed to the item id Jellyfin happens to
+/// be using for it today.
+/// <para>
+/// Item ids are not stable. Replacing a file, which any *arr does on a quality
+/// upgrade, gives Jellyfin a fresh GUID for the same film. Anything keyed by
+/// item id alone loses track of it at that moment.
+/// </para>
+/// </summary>
+public static class MediaIdentity
+{
+    /// <summary>Providers ordered by how reliably they identify this exact
+    /// item. Verified against a live library: episodes carry their own Tvdb id,
+    /// distinct from one another and from the series, so this cannot collapse a
+    /// season into one entry.</summary>
+    private static readonly string[] Providers = { "Imdb", "Tmdb", "Tvdb" };
+
+    /// <summary>
+    /// A stable key such as <c>Movie|Imdb:tt123</c>, or null when the item has
+    /// no provider id. Null is ordinary, not a failure: home video and
+    /// unmatched rips have none, and callers fall back to the item id.
+    /// </summary>
+    public static string? For(BaseItem? item)
+    {
+        var providers = item?.ProviderIds;
+        if (providers is null || providers.Count == 0) return null;
+
+        foreach (var provider in Providers)
+        {
+            if (providers.TryGetValue(provider, out var value) && !string.IsNullOrWhiteSpace(value))
+            {
+                // The type prefix keeps two kinds of media apart should they
+                // ever be given the same number in different namespaces.
+                return item!.GetType().Name + "|" + provider + ":" + value.Trim();
+            }
+        }
+
+        return null;
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
@@ -206,6 +206,72 @@ public sealed class WatchCarryStore
         }
     }
 
+    /// <summary>
+    /// Fills in the media key of entries written before the field existed, and
+    /// reports how many could not be resolved.
+    /// <para>
+    /// Without this an upgrade only protects viewings started after it. Every
+    /// partial viewing already on disk keeps its bare item id, so a file
+    /// replaced tomorrow strands it exactly as before. Resolving them at
+    /// startup, while their items are still in the library, is the difference
+    /// between fixing this going forward and fixing it for the people who
+    /// already have time banked.
+    /// </para>
+    /// <para>
+    /// An entry whose item no longer resolves is already lost and nothing here
+    /// can recover it: the old code stored the item id and nothing else, so
+    /// after the item is gone there is nothing left to match it to. Those are
+    /// counted and returned so the caller can say so out loud rather than let
+    /// the time disappear quietly, which is how this was missed in the first
+    /// place.
+    /// </para>
+    /// </summary>
+    /// <param name="resolve">Maps an item id to a media key, or null when the
+    /// item is gone or carries no provider id.</param>
+    /// <returns>How many were filled in, and how many could not be.</returns>
+    public (int Filled, int Unresolved) BackfillMediaKeys(Func<string, string?> resolve)
+    {
+        ArgumentNullException.ThrowIfNull(resolve);
+
+        var filled = 0;
+        var unresolved = 0;
+
+        foreach (var pair in _entries)
+        {
+            var entry = pair.Value;
+            if (!string.IsNullOrEmpty(entry.MediaKey)) continue;
+
+            string? key;
+            try
+            {
+                key = resolve(entry.ItemId);
+            }
+            catch (Exception)
+            {
+                // One unreadable item must not abort the whole backfill and
+                // leave the rest unprotected.
+                unresolved++;
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(key))
+            {
+                unresolved++;
+                continue;
+            }
+
+            entry.MediaKey = key;
+            filled++;
+        }
+
+        if (filled > 0)
+        {
+            Persist();
+        }
+
+        return (filled, unresolved);
+    }
+
     private void Prune(DateTimeOffset now)
     {
         var removed = false;

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/WatchCarryStore.cs
@@ -42,6 +42,15 @@ public sealed class WatchCarryStore
 
         public string ItemId { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Stable identity of the media itself, such as <c>Movie|Imdb:tt123</c>,
+        /// or null when the item carries no provider id. Item ids are not
+        /// stable: replacing a file gives Jellyfin a new one. Null entries,
+        /// including every entry written before this field existed, still work
+        /// by item id alone.
+        /// </summary>
+        public string? MediaKey { get; set; }
+
         public long Ticks { get; set; }
 
         public DateTimeOffset UpdatedAt { get; set; }
@@ -90,17 +99,44 @@ public sealed class WatchCarryStore
     /// recent. Expired entries are dropped on the way through, which keeps the
     /// store bounded without a background timer.
     /// </summary>
-    public long Peek(string userId, string itemId, DateTimeOffset now)
+    public long Peek(string userId, string itemId, DateTimeOffset now, string? mediaKey = null)
     {
         Prune(now);
+
+        var total = 0L;
 
         if (_entries.TryGetValue(Key(userId, itemId), out var entry)
             && now - entry.UpdatedAt <= _window)
         {
-            return entry.Ticks;
+            total = entry.Ticks;
         }
 
-        return 0;
+        // Same media, different item id. An *arr quality upgrade replaces the
+        // file and Jellyfin mints a new GUID, so everything banked against the
+        // old one becomes unreachable while the viewer keeps watching the same
+        // film. Measured on a live server: 69.6 minutes stranded under a dead
+        // id, 34.8 minutes under the live one, and a finished 95 minute film
+        // refused at 36%.
+        //
+        // Added rather than used as a fallback, because the live id usually
+        // does have an entry, so a fallback would never fire in the case this
+        // exists for. Double counting is not a concern: Remember folds the
+        // older entries away as soon as this total is written back.
+        if (!string.IsNullOrEmpty(mediaKey))
+        {
+            foreach (var pair in _entries)
+            {
+                var other = pair.Value;
+                if (!string.Equals(other.MediaKey, mediaKey, StringComparison.OrdinalIgnoreCase)) continue;
+                if (!string.Equals(other.UserId, userId, StringComparison.OrdinalIgnoreCase)) continue;
+                if (string.Equals(other.ItemId, itemId, StringComparison.OrdinalIgnoreCase)) continue;
+                if (now - other.UpdatedAt > _window) continue;
+
+                total += other.Ticks;
+            }
+        }
+
+        return total;
     }
 
     /// <summary>
@@ -108,11 +144,11 @@ public sealed class WatchCarryStore
     /// because the caller passes the running total for the item, not a delta.
     /// Non-positive values clear the entry instead of storing a useless one.
     /// </summary>
-    public void Remember(string userId, string itemId, long ticks, DateTimeOffset now)
+    public void Remember(string userId, string itemId, long ticks, DateTimeOffset now, string? mediaKey = null)
     {
         if (ticks <= 0)
         {
-            Clear(userId, itemId);
+            Clear(userId, itemId, mediaKey);
             return;
         }
 
@@ -120,17 +156,51 @@ public sealed class WatchCarryStore
         {
             UserId = userId,
             ItemId = itemId,
+            MediaKey = mediaKey,
             Ticks = ticks,
             UpdatedAt = now
         };
 
+        // The caller passes the running total, which Peek already folded the
+        // older ids into, so keeping them would count that time twice on the
+        // next sitting. Consolidating here is what makes the addition in Peek
+        // safe.
+        ForEachSiblingOf(userId, itemId, mediaKey, key => _entries.TryRemove(key, out _));
+
         Persist();
     }
 
-    /// <summary>Drops the carry, called once the item has been credited.</summary>
-    public void Clear(string userId, string itemId)
+    /// <summary>
+    /// Runs an action for every entry that is the same media as this one under
+    /// a different item id. No-op when the item has no stable media key.
+    /// </summary>
+    private void ForEachSiblingOf(string userId, string itemId, string? mediaKey, Action<string> action)
     {
-        if (_entries.TryRemove(Key(userId, itemId), out _))
+        if (string.IsNullOrEmpty(mediaKey)) return;
+
+        foreach (var pair in _entries)
+        {
+            var other = pair.Value;
+            if (!string.Equals(other.MediaKey, mediaKey, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.Equals(other.UserId, userId, StringComparison.OrdinalIgnoreCase)) continue;
+            if (string.Equals(other.ItemId, itemId, StringComparison.OrdinalIgnoreCase)) continue;
+
+            action(pair.Key);
+        }
+    }
+
+    /// <summary>
+    /// Drops the carry, called once the item has been credited. Also drops the
+    /// same media held under other item ids, so a credited film cannot leave an
+    /// orphan behind that resurfaces against a later re-watch.
+    /// </summary>
+    public void Clear(string userId, string itemId, string? mediaKey = null)
+    {
+        var removed = _entries.TryRemove(Key(userId, itemId), out _);
+
+        ForEachSiblingOf(userId, itemId, mediaKey, key => removed |= _entries.TryRemove(key, out _));
+
+        if (removed)
         {
             Persist();
         }

--- a/Jellyfin.Plugin.AchievementBadges/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.AchievementBadges/PluginServiceRegistrator.cs
@@ -42,6 +42,23 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
                 provider.GetRequiredService<MediaBrowser.Common.Configuration.IApplicationPaths>().PluginConfigurationsPath,
                 "achievementbadges",
                 "tracearr-credited.json")));
+        // Shared between the playback tracker, which fills it, and the watch
+        // history scan, which has to drop the carry of items it credits.
+        // While the tracker owned it privately the scan could not reach it, so
+        // a credited item kept its banked minutes and a short rewatch cleared
+        // the threshold on time already spent.
+        serviceCollection.AddSingleton(provider =>
+        {
+            var days = Plugin.Instance?.Configuration?.WatchCarryRetentionDays ?? 7;
+            if (days <= 0) return new WatchCarryStore(System.TimeSpan.Zero);
+
+            return new WatchCarryStore(
+                System.TimeSpan.FromDays(days),
+                System.IO.Path.Combine(
+                    provider.GetRequiredService<MediaBrowser.Common.Configuration.IApplicationPaths>().PluginConfigurationsPath,
+                    "achievementbadges",
+                    "watch-carry.json"));
+        });
         serviceCollection.AddSingleton<LibraryCompletionService>();
         serviceCollection.AddSingleton<RecapService>();
         serviceCollection.AddSingleton<RecommendationService>();

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -350,7 +350,8 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             // ended without credit, so a stream that broke and reconnected is
             // measured as one viewing. See WatchCarryStore for why this is safe.
             var now = DateTimeOffset.UtcNow;
-            var carriedTicks = _carried.Peek(userId, itemId, now);
+            var mediaKey = ResolveMediaKey(item);
+            var carriedTicks = _carried.Peek(userId, itemId, now, mediaKey);
             if (carriedTicks > 0)
             {
                 _logger.LogInformation(
@@ -441,7 +442,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             if (success)
             {
                 // Credited, so a later viewing of the same item starts clean.
-                _carried.Clear(userId, itemId);
+                _carried.Clear(userId, itemId, mediaKey);
                 ReportCarryPersistError();
 
                 _logger.LogInformation(
@@ -453,7 +454,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
                 // Not credited: remember what was genuinely watched so the next
                 // sitting picks up where this one left off instead of starting
                 // from zero.
-                _carried.Remember(userId, itemId, accumulatedPlayTicks, now);
+                _carried.Remember(userId, itemId, accumulatedPlayTicks, now, mediaKey);
                 ReportCarryPersistError();
 
                 _logger.LogDebug(
@@ -532,6 +533,42 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         }
         catch
         {
+        }
+
+        return null;
+    }
+
+    /// <summary>Providers ordered by how reliably they identify this exact
+    /// item. Verified against a live library: episodes carry their own Tvdb id,
+    /// distinct from one another and from the series, so this cannot collapse a
+    /// season into one entry.</summary>
+    private static readonly string[] MediaKeyProviders = { "Imdb", "Tmdb", "Tvdb" };
+
+    /// <summary>
+    /// Stable identity of the media, or null when it carries no provider id.
+    /// <para>
+    /// Item ids are not stable. Replacing a file, which any *arr does on a
+    /// quality upgrade, gives Jellyfin a fresh GUID for the same film, and the
+    /// carry keyed by the old one becomes unreachable mid-viewing. Provider ids
+    /// survive that. Null is fine and common: those entries keep working by
+    /// item id alone, exactly as before.
+    /// </para>
+    /// <para>
+    /// The type prefix keeps two different kinds of media apart should they
+    /// ever be given the same number in different provider namespaces.
+    /// </para>
+    /// </summary>
+    private static string? ResolveMediaKey(BaseItem? item)
+    {
+        var providers = item?.ProviderIds;
+        if (providers is null || providers.Count == 0) return null;
+
+        foreach (var provider in MediaKeyProviders)
+        {
+            if (providers.TryGetValue(provider, out var value) && !string.IsNullOrWhiteSpace(value))
+            {
+                return item!.GetType().Name + "|" + provider + ":" + value.Trim();
+            }
         }
 
         return null;

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -117,9 +117,51 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             _userDataManager.UserDataSaved += OnUserDataSaved;
             _subscribed = true;
             _logger.LogInformation("[AchievementBadges] PlaybackCompletionTracker started, subscribed to session + userdata events.");
+
+            BackfillCarryMediaKeys();
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Gives the viewings already on disk the same protection as new ones, by
+    /// resolving their media identity while their items are still in the
+    /// library. Runs once at startup and is cheap: only entries missing a key
+    /// are looked up, and the store is bounded by its own pruning.
+    /// </summary>
+    private void BackfillCarryMediaKeys()
+    {
+        try
+        {
+            var (filled, unresolved) = _carried.BackfillMediaKeys(itemId =>
+                Guid.TryParse(itemId, out var guid)
+                    ? ResolveMediaKey(_libraryManager.GetItemById(guid))
+                    : null);
+
+            if (filled > 0)
+            {
+                _logger.LogInformation(
+                    "[AchievementBadges] Carried {Count} partial viewings now survive a media file replacement.",
+                    filled);
+            }
+
+            if (unresolved > 0)
+            {
+                // Said out loud rather than swallowed: this is watch time that
+                // is already unreachable, and a watch history scan is the only
+                // way to credit those viewings.
+                _logger.LogInformation(
+                    "[AchievementBadges] {Count} carried partial viewings reference items that are gone or have no "
+                    + "provider id, so they cannot be linked to their media. If a viewer is being refused credit for "
+                    + "something they finished, a watch history scan credits it from Jellyfin's own played flag.",
+                    unresolved);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[AchievementBadges] Could not backfill watch carry media keys; carrying continues by item id.");
+        }
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -63,20 +63,19 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         ILibraryManager libraryManager,
         IUserDataManager userDataManager,
         PlaybackCompletionService playbackCompletionService,
+        WatchCarryStore carried,
         ILogger<PlaybackCompletionTracker> logger)
     {
         _sessionManager = sessionManager;
         _libraryManager = libraryManager;
         _userDataManager = userDataManager;
         _playbackCompletionService = playbackCompletionService;
+        // Shared rather than owned: the watch history scan credits items too,
+        // and it has to be able to drop their carry. While this lived in here
+        // the scan could not reach it, so credited items kept their banked
+        // time and a short rewatch reached the threshold on stale minutes.
+        _carried = carried;
         _logger = logger;
-
-        var days = Plugin.Instance?.Configuration?.WatchCarryRetentionDays ?? 7;
-        _carried = days > 0
-            ? new WatchCarryStore(
-                TimeSpan.FromDays(days),
-                Path.Combine(applicationPaths.PluginConfigurationsPath, "achievementbadges", "watch-carry.json"))
-            : new WatchCarryStore(TimeSpan.Zero);
     }
 
     /// <summary>
@@ -136,7 +135,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         {
             var (filled, unresolved) = _carried.BackfillMediaKeys(itemId =>
                 Guid.TryParse(itemId, out var guid)
-                    ? ResolveMediaKey(_libraryManager.GetItemById(guid))
+                    ? MediaIdentity.For(_libraryManager.GetItemById(guid))
                     : null);
 
             if (filled > 0)
@@ -392,7 +391,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
             // ended without credit, so a stream that broke and reconnected is
             // measured as one viewing. See WatchCarryStore for why this is safe.
             var now = DateTimeOffset.UtcNow;
-            var mediaKey = ResolveMediaKey(item);
+            var mediaKey = MediaIdentity.For(item);
             var carriedTicks = _carried.Peek(userId, itemId, now, mediaKey);
             if (carriedTicks > 0)
             {
@@ -575,42 +574,6 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         }
         catch
         {
-        }
-
-        return null;
-    }
-
-    /// <summary>Providers ordered by how reliably they identify this exact
-    /// item. Verified against a live library: episodes carry their own Tvdb id,
-    /// distinct from one another and from the series, so this cannot collapse a
-    /// season into one entry.</summary>
-    private static readonly string[] MediaKeyProviders = { "Imdb", "Tmdb", "Tvdb" };
-
-    /// <summary>
-    /// Stable identity of the media, or null when it carries no provider id.
-    /// <para>
-    /// Item ids are not stable. Replacing a file, which any *arr does on a
-    /// quality upgrade, gives Jellyfin a fresh GUID for the same film, and the
-    /// carry keyed by the old one becomes unreachable mid-viewing. Provider ids
-    /// survive that. Null is fine and common: those entries keep working by
-    /// item id alone, exactly as before.
-    /// </para>
-    /// <para>
-    /// The type prefix keeps two different kinds of media apart should they
-    /// ever be given the same number in different provider namespaces.
-    /// </para>
-    /// </summary>
-    private static string? ResolveMediaKey(BaseItem? item)
-    {
-        var providers = item?.ProviderIds;
-        if (providers is null || providers.Count == 0) return null;
-
-        foreach (var provider in MediaKeyProviders)
-        {
-            if (providers.TryGetValue(provider, out var value) && !string.IsNullOrWhiteSpace(value))
-            {
-                return item!.GetType().Name + "|" + provider + ":" + value.Trim();
-            }
         }
 
         return null;

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -32,6 +32,14 @@ public class WatchHistoryBackfillService
     private readonly AchievementBadgeService _achievementBadgeService;
     private readonly LibraryCompletionService _libraryCompletionService;
     private readonly TracearrCreditLedger _tracearrLedger;
+
+    /// <summary>
+    /// Shared with the playback tracker. The scan credits items without ever
+    /// going through a playback stop, which is the only path that used to drop
+    /// a carry, so anything it credits keeps its banked minutes unless this
+    /// clears them.
+    /// </summary>
+    private readonly WatchCarryStore _carried;
     private readonly ILogger<WatchHistoryBackfillService> _logger;
 
     public WatchHistoryBackfillService(
@@ -41,6 +49,7 @@ public class WatchHistoryBackfillService
         AchievementBadgeService achievementBadgeService,
         LibraryCompletionService libraryCompletionService,
         TracearrCreditLedger tracearrLedger,
+        WatchCarryStore carried,
         ILogger<WatchHistoryBackfillService> logger)
     {
         _libraryManager = libraryManager;
@@ -49,6 +58,7 @@ public class WatchHistoryBackfillService
         _achievementBadgeService = achievementBadgeService;
         _libraryCompletionService = libraryCompletionService;
         _tracearrLedger = tracearrLedger;
+        _carried = carried;
         _logger = logger;
     }
 
@@ -197,7 +207,11 @@ public class WatchHistoryBackfillService
     private int AdoptWithoutCrediting(string userId, Jellyfin.Database.Implementations.Entities.User user)
     {
         var config = Plugin.Instance?.Configuration;
-        if (!TracearrClient.TryBuildBaseUri(config!.TracearrUrl, out var baseUri, out _)) return 0;
+        if (!TracearrClient.TryBuildBaseUri(config!.TracearrUrl, out var baseUri, out var urlError))
+        {
+            _logger.LogWarning("[AchievementBadges] Tracearr not used for {Username}: {Error}", user.Username, urlError);
+            return 0;
+        }
 
         try
         {
@@ -205,7 +219,12 @@ public class WatchHistoryBackfillService
             var accountId = client
                 .ResolveAccountIdAsync(baseUri!, config.TracearrApiToken, userId, CancellationToken.None)
                 .GetAwaiter().GetResult();
-            if (string.IsNullOrEmpty(accountId)) return 0;
+
+            if (string.IsNullOrEmpty(accountId))
+            {
+                _logger.LogInformation("[AchievementBadges] No Tracearr account matches {Username}.", user.Username);
+                return 0;
+            }
 
             var plays = client
                 .GetHistoryAsync(baseUri!, config.TracearrApiToken, accountId!, CancellationToken.None)
@@ -217,7 +236,20 @@ public class WatchHistoryBackfillService
                 .Select(id => id!)
                 .ToList();
 
-            return _tracearrLedger.Remember(userId, ids);
+            var adopted = _tracearrLedger.Remember(userId, ids);
+
+            // The counterpart of the "credited N plays" line, and the reason
+            // this path needed one at all: adopting writes nothing to the
+            // profile, so without a log the first sync after an upgrade leaves
+            // no trace anywhere an admin would look. The only evidence was the
+            // ledger file appearing on disk.
+            _logger.LogInformation(
+                "[AchievementBadges] Tracearr recorded {Count} plays for {Username} as already counted, "
+                + "crediting none: first sync for this user, so their counters may already include these. "
+                + "A watch history scan clears the ledger and counts them honestly if they never were.",
+                adopted, user.Username);
+
+            return adopted;
         }
         catch (Exception ex)
         {
@@ -246,7 +278,16 @@ public class WatchHistoryBackfillService
 
             foreach (var item in _libraryManager.GetItemsResult(query).Items)
             {
-                ids.Add(item.Id.ToString("D"));
+                var id = item.Id.ToString("D");
+                ids.Add(id);
+
+                // This item is about to be counted as watched, so whatever was
+                // banked toward finishing it has been spent. Leaving it would
+                // let a later partial rewatch reach the 80% gate on minutes
+                // from the first viewing: measured on a live server, an item
+                // sat at 72.3% carried after being credited, so 8% more of it
+                // would have earned a rewatch.
+                _carried.Clear(user.Id.ToString("D"), id, MediaIdentity.For(item));
             }
         }
 


### PR DESCRIPTION
Closes #90. **Stacked on #89**, whose media key it uses to also drop siblings under replaced item ids. Merge that one first and this diff shrinks to what it actually changes.

`Clear` was only ever reachable from the playback path, because the carry store was constructed inside `PlaybackCompletionTracker` and held privately. The scan credits from Jellyfin's played flag and never touched it, so credited items kept their banked minutes.

Live measurement after a scan on my server: 10 of 40 entries sat on already-played items, one at 72.3% of its runtime. Eight percent more of that item would have earned a rewatch credit.

## Shape of the change

The store moves to DI, shared by the tracker that fills it and the scan that drops it. That mirrors how `TracearrCreditLedger` is already registered, including reading the retention window from config at registration time, which is where the tracker read it before.

The clear happens inside `PlayedItemIds`, where the scan enumerates played items. That is the same set it credits, which matters: partial viewings still in progress are not in it and are left alone. Wiping the whole carry on reset would have been simpler and would have punished anyone who ran a scan halfway through a film.

`MediaIdentity` is lifted out of the tracker so both callers resolve the same key rather than two copies drifting.

## What the test does and does not prove

`TheBackfillCanReachTheWatchCarryStore` pins the constructor dependency, not the call. Standing up the whole backfill to exercise the call is more machinery than the change warrants, and I would rather say that than let a passing test imply coverage it does not have. It does catch the regression that caused this: the dependency being absent.

The evidence the behaviour is right is the measurement above. I will post the after numbers here once I have run a scan on the fixed build.

Build clean, 198 of 198.
