### PR TITLE
fix(carry): put the clear where the scan actually runs

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -262,6 +262,35 @@ public class WatchHistoryBackfillService
     /// Item ids this user has played that the library can still prove, which
     /// is what the in-scan pass gets for free from its own replay.
     /// </summary>
+    /// <summary>
+    /// Drops the watch carry of every item the scan just credited.
+    /// <para>
+    /// The scan credits from Jellyfin's played flag without ever going through
+    /// a playback stop, which is the only path that used to clear a carry. So
+    /// the banked minutes survived, and a later partial rewatch could reach the
+    /// 80% gate on time already spent.
+    /// </para>
+    /// </summary>
+    private void ClearCarryFor(Guid userGuid, HashSet<string> creditedItemIds)
+    {
+        var userId = userGuid.ToString("D");
+
+        foreach (var id in creditedItemIds)
+        {
+            try
+            {
+                var item = Guid.TryParse(id, out var itemGuid) ? _libraryManager.GetItemById(itemGuid) : null;
+                _carried.Clear(userId, id, MediaIdentity.For(item));
+            }
+            catch (Exception ex)
+            {
+                // One unreadable item must not abort the sweep and leave the
+                // rest of the credited set carrying stale minutes.
+                _logger.LogDebug(ex, "[AchievementBadges] Could not clear watch carry for item {ItemId}.", id);
+            }
+        }
+    }
+
     private HashSet<string> PlayedItemIds(Jellyfin.Database.Implementations.Entities.User user)
     {
         var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -278,16 +307,7 @@ public class WatchHistoryBackfillService
 
             foreach (var item in _libraryManager.GetItemsResult(query).Items)
             {
-                var id = item.Id.ToString("D");
-                ids.Add(id);
-
-                // This item is about to be counted as watched, so whatever was
-                // banked toward finishing it has been spent. Leaving it would
-                // let a later partial rewatch reach the 80% gate on minutes
-                // from the first viewing: measured on a live server, an item
-                // sat at 72.3% carried after being credited, so 8% more of it
-                // would have earned a rewatch.
-                _carried.Clear(user.Id.ToString("D"), id, MediaIdentity.For(item));
+                ids.Add(item.Id.ToString("D"));
             }
         }
 
@@ -608,6 +628,19 @@ public class WatchHistoryBackfillService
             // happened. Crediting them after the floor would stack them on top
             // of themselves and inflate every total they feed.
             var tracearrCredited = RunTracearrPass(userId, username, creditedItemIds);
+
+            // Everything in that set has just been counted as watched, so the
+            // minutes banked toward finishing it have been spent. Leaving them
+            // lets a later partial rewatch reach the 80% gate on time from the
+            // first viewing.
+            //
+            // Placed here rather than in PlayedItemIds, which is where an
+            // earlier attempt put it: that helper serves the standalone
+            // Tracearr sync, and the scan builds creditedItemIds from its own
+            // queries and never calls it. The clear therefore never ran during
+            // a scan, which is the case it exists for. Measured after a real
+            // scan: three entries survived on already-credited items.
+            ClearCarryFor(userGuid, creditedItemIds);
 
             // Issue #48 companion: floor the rebuilt counters at their
             // pre scan values so deleted media never shrinks lifetime totals.


### PR DESCRIPTION
Fixes what #91 promised and did not do. I measured the failure, wrote this, deployed it, and measured again before opening the PR, which is the order I should have used the first time.

## What was wrong

#91 put the clear inside `PlayedItemIds`. I described that helper as "where the scan enumerates played items". It is not: it serves `SyncTracearrForUser`, the standalone button.

The scan builds its own `creditedItemIds` from separate `IsPlayed` queries at three sites (movies, books, episodes) and hands that set to `RunTracearrPass`. It never calls `PlayedItemIds`, so the clear never ran during a scan, which is the only case it exists for.

## Measured, both times

Live server, real watch history scan, counting carry entries sitting on items that scan had just credited.

**With #91 as merged:**

```
before scan:  3 entries for that user
after  scan:  3 entries          unchanged
```

**With this branch:**

```
carry entries total:      41 -> 38
stuck on credited items:  11 -> 8
that user specifically:    3 -> 0
```

The total dropping by exactly three is the part worth checking, not the zero. Had it fallen further, the sweep would be eating watch time from items still legitimately in progress. Three stuck, three cleared, nothing else touched. The remaining eight belong to users who were not scanned, which is the expected behaviour rather than residue.

## The change

A sweep over `creditedItemIds` immediately after the Tracearr pass, which is the set the scan actually credits. An item that fails to resolve is logged at debug and skipped rather than aborting the sweep and leaving the rest carrying stale minutes.

## On the tests

200 of 200, and I want to be blunt that this means little here: the suite also passed 198 of 198 with the broken version. The wiring test pins the constructor dependency, not the call. I flagged that gap when I sent #91 and then talked myself past it. The evidence for this PR is the before-and-after above, not the green run.
