### PR TITLE
fix: recompute discography percentages on live playback, not only on scan

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/ArtistCompletionLiveRecomputeTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/ArtistCompletionLiveRecomputeTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #24 follow-up: discography percentages were computed by exactly one
+/// writer, the full recompute, whose only caller was the watch history scan.
+/// Listening to an album live never moved them, so "Sampler" (hear 10% of one
+/// artist) could not unlock without an admin running a scan. These pin the
+/// live path: the scoped recompute must MERGE into the stored map, because
+/// replace semantics there would wipe every other artist on each play.
+/// </summary>
+public class ArtistCompletionLiveRecomputeTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly AchievementBadgeService _badges;
+
+    private static readonly Guid Listener = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private string ListenerId => Listener.ToString("D");
+
+    public ArtistCompletionLiveRecomputeTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "ablive_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var paths = new Mock<IApplicationPaths>();
+        paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        var users = new Mock<IUserManager>();
+        users.Setup(m => m.GetUserById(Listener)).Returns(new User("Listener", "prov", "reset"));
+
+        _badges = new AchievementBadgeService(
+            paths.Object,
+            users.Object,
+            new WebhookNotifier(NullLogger<WebhookNotifier>.Instance),
+            new AuditLogService(paths.Object, NullLogger<AuditLogService>.Instance),
+            NullLogger<AchievementBadgeService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void MergePreservesArtistsItWasNotAskedAbout()
+    {
+        // The exact defect a replace would cause: play one Underscores track,
+        // lose the Aphex Twin percentage the last scan computed.
+        _badges.UpdateArtistCompletionPercents(ListenerId, new Dictionary<string, int>
+        {
+            ["Aphex Twin"] = 95,
+            ["Underscores"] = 40,
+        });
+
+        _badges.MergeArtistCompletionPercents(ListenerId, new Dictionary<string, int>
+        {
+            ["Underscores"] = 50,
+        });
+
+        var counters = _badges.PeekProfile(ListenerId)!.Counters;
+        Assert.Equal(95, counters.ArtistCompletionPercents["Aphex Twin"]);
+        Assert.Equal(50, counters.ArtistCompletionPercents["Underscores"]);
+    }
+
+    [Fact]
+    public void MergeUnlocksTheBadgeTheIssueWasAbout()
+    {
+        // Crossing 10% through the live path must behave exactly like
+        // crossing it through a scan: evaluate and unlock immediately.
+        // 30 sits between the Regular Listener (25) and Fan (50) rungs.
+        _badges.MergeArtistCompletionPercents(ListenerId, new Dictionary<string, int>
+        {
+            ["Underscores"] = 30,
+        });
+
+        var profile = _badges.PeekProfile(ListenerId)!;
+        var unlocked = profile.Badges.Where(b => b.Unlocked).Select(b => b.Id).ToList();
+        Assert.Contains("artist-sampler", unlocked);
+        Assert.Contains("artist-listener", unlocked);
+        Assert.DoesNotContain("artist-fan", unlocked);
+    }
+
+    [Fact]
+    public void MergeWithNothingToSayTouchesNothing()
+    {
+        // A track whose artists resolve to no MusicArtist item (or all under
+        // the 2-track floor) produces an empty result. That must be a no-op,
+        // not a profile write.
+        _badges.MergeArtistCompletionPercents(ListenerId, new Dictionary<string, int>());
+        Assert.Null(_badges.PeekProfile(ListenerId));
+    }
+
+    [Fact]
+    public void TheTrackerCanReachTheCompletionService()
+    {
+        // Same shape as LibraryCompletionWiringTests, and the same honesty
+        // about it: this pins the dependency, not the call. Exercising the
+        // call needs Jellyfin's event stack; the evidence for it is the live
+        // validation recorded in the PR.
+        var constructor = typeof(PlaybackCompletionTracker)
+            .GetConstructors()
+            .Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(LibraryCompletionService));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -1114,7 +1114,12 @@ public class AchievementBadgesController : ControllerBase
             return BadRequest(new { Message = "Invalid user id." });
         }
         var result = _libraryCompletionService.RecomputeForUser(guid);
-        return Ok(new { LibraryCompletionPercents = result });
+        // [issue #24 follow-up] Recompute the discography percentages too.
+        // Before this, the full artist recompute was reachable only through
+        // the watch history scan, so a broken or undesired scan left no way
+        // to refresh them at all.
+        var artists = _libraryCompletionService.RecomputeArtistsForUser(guid);
+        return Ok(new { LibraryCompletionPercents = result, ArtistCompletionPercents = artists });
     }
 
     [HttpGet("users/{userId}/library-completion")]

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -1247,6 +1247,33 @@ public class AchievementBadgeService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Merge variant for the live playback path, which recomputes only the
+    /// artists of the track that just finished. Replace semantics there would
+    /// wipe every other artist's percentage on each play; only the full scan,
+    /// which recomputes everyone, may replace.
+    /// </summary>
+    public void MergeArtistCompletionPercents(string userId, Dictionary<string, int> percents)
+    {
+        if (percents is null || percents.Count == 0)
+        {
+            return;
+        }
+
+        userId = NormalizeUserId(userId);
+        lock (_lock)
+        {
+            var profile = GetOrCreateProfile(userId);
+            foreach (var kv in percents)
+            {
+                profile.Counters.ArtistCompletionPercents[kv.Key] = kv.Value;
+            }
+
+            EvaluateBadges(profile, userId);
+            Save();
+        }
+    }
+
     public void RegisterLogin(string userId)
     {
         userId = NormalizeUserId(userId);

--- a/Jellyfin.Plugin.AchievementBadges/Services/LibraryCompletionService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/LibraryCompletionService.cs
@@ -82,7 +82,13 @@ public class LibraryCompletionService
         }
         catch (Exception ex)
         {
+            // Return without writing: this method replaces the stored map, so
+            // persisting the partial result of a failed enumeration would wipe
+            // percentages that are still true. An empty result from a
+            // successful enumeration (no libraries) is legitimate and still
+            // written below.
             _logger.LogWarning(ex, "[AchievementBadges] Library completion recompute failed for user {UserId}", userGuid);
+            return result;
         }
 
         _badgeService.UpdateLibraryCompletionPercents(userGuid.ToString("D"), result);
@@ -129,31 +135,11 @@ public class LibraryCompletionService
             {
                 try
                 {
-                    var totalQuery = new InternalItemsQuery(user)
-                    {
-                        IncludeItemTypes = new[] { BaseItemKind.Audio },
-                        AlbumArtistIds = new[] { artist.Id },
-                        Recursive = true,
-                        EnableTotalRecordCount = false
-                    };
-
-                    var total = _libraryManager.GetItemsResult(totalQuery).Items.Count;
-                    if (total < 2) continue;
-
-                    var playedQuery = new InternalItemsQuery(user)
-                    {
-                        IncludeItemTypes = new[] { BaseItemKind.Audio },
-                        AlbumArtistIds = new[] { artist.Id },
-                        IsPlayed = true,
-                        Recursive = true,
-                        EnableTotalRecordCount = false
-                    };
-
-                    var played = _libraryManager.GetItemsResult(playedQuery).Items.Count;
                     var name = artist.Name ?? string.Empty;
-                    if (!string.IsNullOrWhiteSpace(name))
+                    if (!string.IsNullOrWhiteSpace(name)
+                        && TryComputeArtistPercent(user, artist.Id, out var percent))
                     {
-                        result[name] = (int)Math.Round(100.0 * played / total);
+                        result[name] = percent;
                     }
                 }
                 catch (Exception ex)
@@ -164,11 +150,119 @@ public class LibraryCompletionService
         }
         catch (Exception ex)
         {
+            // Same guard as the library recompute above: replace semantics
+            // plus a failed enumeration must not wipe stored percentages.
             _logger.LogWarning(ex, "[AchievementBadges] Artist completion recompute failed for user {UserId}", userGuid);
+            return result;
         }
 
         _badgeService.UpdateArtistCompletionPercents(userGuid.ToString("D"), result);
         return result;
+    }
+
+    /// <summary>
+    /// Scoped variant for the live playback path: recomputes only the named
+    /// artists and merges them into the stored map. Before this existed the
+    /// dictionary had exactly one writer, the full recompute above, and its
+    /// only caller was the watch history scan — so listening to an album live
+    /// never moved the discography badges until an admin happened to run a
+    /// scan (reported in issue #24 as "Sampler" not unlocking).
+    /// <para>
+    /// Artists are resolved by name through a MusicArtist query rather than
+    /// ILibraryManager.GetArtist, because GetArtist is get-or-create and
+    /// would write artist entries into the library as a side effect.
+    /// </para>
+    /// <para>
+    /// The single-track skip rule can leave a stale entry behind when an
+    /// artist's library shrinks to one track: the merge never deletes, so the
+    /// old percentage stays until the next full recompute replaces the map.
+    /// Accepted: the full scan remains the reconciler, this path is additive.
+    /// </para>
+    /// </summary>
+    public Dictionary<string, int> RecomputeArtistsForUser(Guid userGuid, IReadOnlyCollection<string> artistNames)
+    {
+        var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        if (artistNames is null || artistNames.Count == 0)
+        {
+            return result;
+        }
+
+        var user = _userManager.GetUserById(userGuid);
+        if (user is null)
+        {
+            return result;
+        }
+
+        foreach (var name in artistNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            try
+            {
+                var artistQuery = new InternalItemsQuery(user)
+                {
+                    IncludeItemTypes = new[] { BaseItemKind.MusicArtist },
+                    Name = name,
+                    Recursive = true,
+                    EnableTotalRecordCount = false
+                };
+
+                foreach (var artist in _libraryManager.GetItemsResult(artistQuery).Items)
+                {
+                    if (TryComputeArtistPercent(user, artist.Id, out var percent))
+                    {
+                        result[name] = percent;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "[AchievementBadges] Scoped artist completion calc failed for {Artist}", name);
+            }
+        }
+
+        _badgeService.MergeArtistCompletionPercents(userGuid.ToString("D"), result);
+        return result;
+    }
+
+    /// <summary>
+    /// Played tracks over the artist's tracks, counted on album artist. False
+    /// for artists with fewer than two tracks — their percentage is only ever
+    /// 0 or 100, which would hand out "completed an artist" for one play.
+    /// </summary>
+    private bool TryComputeArtistPercent(Jellyfin.Database.Implementations.Entities.User user, Guid artistId, out int percent)
+    {
+        percent = 0;
+
+        var totalQuery = new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Audio },
+            AlbumArtistIds = new[] { artistId },
+            Recursive = true,
+            EnableTotalRecordCount = false
+        };
+
+        var total = _libraryManager.GetItemsResult(totalQuery).Items.Count;
+        if (total < 2)
+        {
+            return false;
+        }
+
+        var playedQuery = new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Audio },
+            AlbumArtistIds = new[] { artistId },
+            IsPlayed = true,
+            Recursive = true,
+            EnableTotalRecordCount = false
+        };
+
+        var played = _libraryManager.GetItemsResult(playedQuery).Items.Count;
+        percent = (int)Math.Round(100.0 * played / total);
+        return true;
     }
 
     public Dictionary<string, Dictionary<string, int>> RecomputeAll()

--- a/Jellyfin.Plugin.AchievementBadges/Services/LibraryCompletionService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/LibraryCompletionService.cs
@@ -164,7 +164,7 @@ public class LibraryCompletionService
     /// Scoped variant for the live playback path: recomputes only the named
     /// artists and merges them into the stored map. Before this existed the
     /// dictionary had exactly one writer, the full recompute above, and its
-    /// only caller was the watch history scan — so listening to an album live
+    /// only caller was the watch history scan, so listening to an album live
     /// never moved the discography badges until an admin happened to run a
     /// scan (reported in issue #24 as "Sampler" not unlocking).
     /// <para>
@@ -230,7 +230,7 @@ public class LibraryCompletionService
 
     /// <summary>
     /// Played tracks over the artist's tracks, counted on album artist. False
-    /// for artists with fewer than two tracks — their percentage is only ever
+    /// for artists with fewer than two tracks, whose percentage is only ever
     /// 0 or 100, which would hand out "completed an artist" for one play.
     /// </summary>
     private bool TryComputeArtistPercent(Jellyfin.Database.Implementations.Entities.User user, Guid artistId, out int percent)

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -252,7 +252,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
     /// [issue #24 follow-up] Refresh the discography percentages of this
     /// track's album artists when its played flag changes. The metric is
     /// defined over Jellyfin's IsPlayed (that is what the scan counts), so the
-    /// trigger is Jellyfin's own played-flag save — not this plugin's credit
+    /// trigger is Jellyfin's own played-flag save, not this plugin's credit
     /// decision, which can lag it. Without this hook the percentages had one
     /// writer, the watch history scan, and a user could listen to an entire
     /// album live without "Sampler" ever unlocking.
@@ -262,7 +262,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         // TogglePlayed passes in both directions: unmarking a track changes
         // the truthful percentage too, and unlocked badges are never revoked.
         // PlaybackFinished fires on every stop, not only completion, so it is
-        // gated on Played — otherwise each skipped track in a shuffle would
+        // gated on Played, otherwise each skipped track in a shuffle would
         // pay the recompute for nothing.
         var toggled = reason.Equals("TogglePlayed", StringComparison.OrdinalIgnoreCase);
         var finishedPlayed = reason.Equals("PlaybackFinished", StringComparison.OrdinalIgnoreCase)

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -22,6 +22,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
     private readonly ILibraryManager _libraryManager;
     private readonly IUserDataManager _userDataManager;
     private readonly PlaybackCompletionService _playbackCompletionService;
+    private readonly LibraryCompletionService _libraryCompletionService;
     private readonly ILogger<PlaybackCompletionTracker> _logger;
     private bool _subscribed;
     private bool _disposed;
@@ -63,6 +64,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         ILibraryManager libraryManager,
         IUserDataManager userDataManager,
         PlaybackCompletionService playbackCompletionService,
+        LibraryCompletionService libraryCompletionService,
         WatchCarryStore carried,
         ILogger<PlaybackCompletionTracker> logger)
     {
@@ -70,6 +72,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         _libraryManager = libraryManager;
         _userDataManager = userDataManager;
         _playbackCompletionService = playbackCompletionService;
+        _libraryCompletionService = libraryCompletionService;
         // Shared rather than owned: the watch history scan credits items too,
         // and it has to be able to drop their carry. While this lived in here
         // the scan could not reach it, so credited items kept their banked
@@ -195,38 +198,94 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         {
             var item = e?.Item;
             if (item is null) return;
-            if (!string.Equals(item.GetType().Name, "Book", StringComparison.OrdinalIgnoreCase)) return;
-            if (e!.UserData is null || !e.UserData.Played) return;
+            if (e!.UserId == Guid.Empty) return;
 
             var reason = e.SaveReason.ToString();
-            if (!reason.Equals("TogglePlayed", StringComparison.OrdinalIgnoreCase)
-                && !reason.Equals("PlaybackFinished", StringComparison.OrdinalIgnoreCase))
+            var typeName = item.GetType().Name;
+
+            if (string.Equals(typeName, "Book", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                HandleBookUserData(e, item, reason);
             }
-
-            if (e.UserId == Guid.Empty) return;
-
-            var context = new PlaybackContext
+            else if (string.Equals(typeName, "Audio", StringComparison.OrdinalIgnoreCase))
             {
-                UserId = e.UserId.ToString("D"),
-                ItemId = item.Id.ToString("D"),
-                IsBook = true,
-                LibraryName = ResolveLibraryName(item),
-                PlayedAt = DateTimeOffset.Now,
-                ProductionYear = item.ProductionYear,
-                Genres = GetEffectiveGenres(item),
-                Tags = GetEffectiveTags(item),
-            };
-
-            _playbackCompletionService.RecordBookCompletion(context);
-            _logger.LogInformation(
-                "[AchievementBadges] Book marked read: user={UserId} item={ItemId} reason={Reason}",
-                e.UserId, item.Id, reason);
+                // Exact type only: AudioBook and MusicVideo are excluded here
+                // the same way the scan's Audio query excludes them.
+                HandleAudioUserData(e, item, reason);
+            }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[AchievementBadges] Failed to process book completion from UserDataSaved.");
+            _logger.LogError(ex, "[AchievementBadges] Failed to process UserDataSaved event.");
+        }
+    }
+
+    private void HandleBookUserData(UserDataSaveEventArgs e, BaseItem item, string reason)
+    {
+        if (e.UserData is null || !e.UserData.Played) return;
+
+        if (!reason.Equals("TogglePlayed", StringComparison.OrdinalIgnoreCase)
+            && !reason.Equals("PlaybackFinished", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var context = new PlaybackContext
+        {
+            UserId = e.UserId.ToString("D"),
+            ItemId = item.Id.ToString("D"),
+            IsBook = true,
+            LibraryName = ResolveLibraryName(item),
+            PlayedAt = DateTimeOffset.Now,
+            ProductionYear = item.ProductionYear,
+            Genres = GetEffectiveGenres(item),
+            Tags = GetEffectiveTags(item),
+        };
+
+        _playbackCompletionService.RecordBookCompletion(context);
+        _logger.LogInformation(
+            "[AchievementBadges] Book marked read: user={UserId} item={ItemId} reason={Reason}",
+            e.UserId, item.Id, reason);
+    }
+
+    /// <summary>
+    /// [issue #24 follow-up] Refresh the discography percentages of this
+    /// track's album artists when its played flag changes. The metric is
+    /// defined over Jellyfin's IsPlayed (that is what the scan counts), so the
+    /// trigger is Jellyfin's own played-flag save — not this plugin's credit
+    /// decision, which can lag it. Without this hook the percentages had one
+    /// writer, the watch history scan, and a user could listen to an entire
+    /// album live without "Sampler" ever unlocking.
+    /// </summary>
+    private void HandleAudioUserData(UserDataSaveEventArgs e, BaseItem item, string reason)
+    {
+        // TogglePlayed passes in both directions: unmarking a track changes
+        // the truthful percentage too, and unlocked badges are never revoked.
+        // PlaybackFinished fires on every stop, not only completion, so it is
+        // gated on Played — otherwise each skipped track in a shuffle would
+        // pay the recompute for nothing.
+        var toggled = reason.Equals("TogglePlayed", StringComparison.OrdinalIgnoreCase);
+        var finishedPlayed = reason.Equals("PlaybackFinished", StringComparison.OrdinalIgnoreCase)
+            && e.UserData?.Played == true;
+        if (!toggled && !finishedPlayed)
+        {
+            return;
+        }
+
+        // AlbumArtists first: discography is counted on album artist, so a
+        // guest appearance must not refresh the guest's own percentage.
+        var artists = GetItemStringList(item, "AlbumArtists") ?? GetItemStringList(item, "Artists");
+        if (artists is null || artists.Count == 0)
+        {
+            return;
+        }
+
+        var result = _libraryCompletionService.RecomputeArtistsForUser(e.UserId, artists);
+        if (result.Count > 0)
+        {
+            _logger.LogDebug(
+                "[AchievementBadges] Discography refresh: user={UserId} item={ItemId} reason={Reason} artists={Artists}",
+                e.UserId, item.Id, reason, string.Join(", ", result.Keys));
         }
     }
 
@@ -654,10 +713,14 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
     {
         try
         {
-            var prop = item.GetType().GetProperty(propertyName);
-            if (prop?.GetValue(item) is string[] arr && arr.Length > 0)
+            // Audio.Artists / AlbumArtists are typed IReadOnlyList<string> in
+            // 10.11; the previous `is string[]` pattern only matched when the
+            // runtime value happened to be an array, silently dropping the
+            // artists whenever Jellyfin handed back a List<string>.
+            if (item.GetType().GetProperty(propertyName)?.GetValue(item)
+                is IReadOnlyList<string> { Count: > 0 } list)
             {
-                return new List<string>(arr);
+                return new List<string>(list);
             }
         }
         catch


### PR DESCRIPTION
Fixes #98, reported inside #24 by @Daemon-Network ("Sampler" not unlocking after playing half an album).

## The defect

`ArtistCompletionPercents` had exactly one writer, the full recompute in `LibraryCompletionService`, and that writer had exactly one caller, the watch history scan. The live playback credit path bumps every other music counter and never touches the percentages, so the Discography ladder could not move without an admin running a scan.

## What this does

**Live trigger.** `PlaybackCompletionTracker` already subscribes to `UserDataSaved` for ebooks; the handler now also dispatches `Audio` items. `TogglePlayed` (both directions, because unmarking changes the truthful percentage too and unlocks are never revoked) and `PlaybackFinished` with `Played=true` refresh the discography of that track's album artists. The gate on `Played` matters: `PlaybackFinished` fires on every stop, so without it each skipped track in a shuffle would pay a recompute for nothing.

The trigger is deliberately Jellyfin's played flag rather than this plugin's credit decision: the metric is defined over `IsPlayed` (that is what the scan's queries count), so anchoring the refresh to the same signal keeps the live value and the scan value identical by construction.

**Scoped recompute + merge.** The new `RecomputeArtistsForUser(userGuid, artistNames)` overload recomputes only the named artists and merges through a new `MergeArtistCompletionPercents`. Merge, not replace: with the existing replace-semantics writer, one play would wipe every other artist's stored percentage. Artist resolution goes through a `MusicArtist` `Name` query, **not** `ILibraryManager.GetArtist`, which is get-or-create and would insert artist entries into the library as a side effect.

**Manual path.** `POST users/{userId}/library-completion/recompute` now recomputes the artist percentages alongside the library ones and returns both. Until now the full artist recompute was reachable exclusively through the scan; anyone whose scan is broken (see #97) or who simply doesn't want to run one had no way to refresh discography.

**Two hardenings found while tracing:**

1. Both full recomputes used to write their result even when the outer library enumeration threw. Replace semantics plus a transient failure meant good stored percentages got wiped by an empty map. They now return without writing on the outer exception. A legitimately empty result (no music libraries) still writes, as it should.
2. `GetItemStringList` in the tracker matched `is string[]`, but `Audio.Artists`/`AlbumArtists` are typed `IReadOnlyList<string>` in 10.11, so whenever the runtime value is not literally an array, live plays silently lost their artist list, which also starves `MusicArtistsListened`. It now accepts any `IReadOnlyList<string>`, matching what the backfill's own helper already did.

## Behavior notes

* Counted on **album artist**, consistent with the scan: a guest appearance does not refresh the guest's own percentage. Tracks with no AlbumArtists fall back to Artists.
* Exact `Audio` type only. `AudioBook` and `MusicVideo` are excluded, the same way the scan's Audio query excludes them.
* The single-track-artist skip rule can leave a stale entry when an artist's library shrinks to one track; the merge never deletes, and the next full recompute (scan or endpoint) reconciles. Documented in code.
* Cost per credited track: one `MusicArtist` lookup plus two count queries per album artist, then one badge evaluation. Marking a whole album played fires this once per track; bounded by album size and in line with the per-play work the credit path already does. If that ever shows up on very large bulk operations, coalescing can be added later. Kept simple here on purpose.

## Validation

Being straight about the limits, same as the tests say in their comments: my library has **no audio at all**, so the live event path could not be exercised against real data here. What is verified:

* Build clean under `TreatWarningsAsErrors`, full suite **206/206** (5 new).
* The new tests pin the merge semantics (preserves untouched artists, unlocks `artist-sampler`/`artist-listener` at 30% without `artist-fan`, empty merge is a no-op that creates no profile) and pin the tracker→service dependency, wiring-test style.
* API surface checked by reflection against the exact `Jellyfin.Controller` 10.11.6 assemblies: `InternalItemsQuery.Name` exists and is settable, `UserDataSaveEventArgs` carries `Item`/`UserData`/`SaveReason`/`UserId`, and `Audio.AlbumArtists` is `IReadOnlyList<string>` (the type mismatch behind hardening 2).

@Daemon-Network, if you can run this build: play any track of an artist with 2+ tracks to completion, and the percentage should move immediately, with no scan. `POST Plugins/AchievementBadges/users/{id}/library-completion/recompute` now also returns `ArtistCompletionPercents`, which gives you a direct way to check what the server thinks of Underscores.