### PR TITLE
Targeted achievements: badges that point at one series, season, collection or item (#107)

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/ArtistCompletionTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/ArtistCompletionTests.cs
@@ -17,14 +17,18 @@ namespace Jellyfin.Plugin.AchievementBadges.Tests;
 public class ArtistCompletionTests
 {
     [Fact]
-    public void TheMetricIsAppendedLast_SoStoredOrdinalsDoNotShift()
+    public void TheMetricKeepsItsOrdinal_SoStoredValuesDoNotShift()
     {
         // Badge progress is serialised by enum ordinal. Inserting a value in
         // the middle would silently repoint every stored badge above it at a
         // different metric, which is unrecoverable without a rebuild.
-        var values = System.Enum.GetValues<AchievementMetric>();
-
-        Assert.Equal(AchievementMetric.ArtistCompletionPercent, values[^1]);
+        //
+        // This used to assert the metric was LAST in the enum, which is a
+        // proxy for the real invariant and fails on every correct append after
+        // it (issue #107 added two). Pinning the ordinal tests the thing that
+        // actually matters: 70 is where this metric's stored values live, and
+        // it must stay 70 forever.
+        Assert.Equal(70, (int)AchievementMetric.ArtistCompletionPercent);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.AchievementBadges.Tests/ObservedTargetsTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/ObservedTargetsTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #107. The recompute is bounded by what the badges actually
+/// reference, so this walk is the thing standing between a targeted badge and
+/// a full library sweep on every play. These pin the walk, the dedup and the
+/// cap, including the case the cap exists for: an admin who authored more
+/// targets than the server should chase.
+/// </summary>
+public class ObservedTargetsTests
+{
+    private static CustomBadge Leaf(AchievementMetric metric, string parameter, bool enabled = true)
+    {
+        return new CustomBadge
+        {
+            Name = parameter,
+            Enabled = enabled,
+            Criteria = new CustomBadgeCriteria
+            {
+                Metric = metric,
+                MetricParameter = parameter,
+                Threshold = 100,
+            },
+        };
+    }
+
+    private static string Ref(string name) => Guid.NewGuid().ToString("N") + "|" + name;
+
+    [Fact]
+    public void ALeafTargetIsCollected()
+    {
+        var badges = new[] { Leaf(AchievementMetric.ContainerCompletionPercent, Ref("One Piece")) };
+
+        var targets = ObservedTargets.Collect(badges, cap: 50, out var dropped);
+
+        var target = Assert.Single(targets);
+        Assert.Equal(AchievementMetric.ContainerCompletionPercent, target.Metric);
+        Assert.Equal("One Piece", target.Name);
+        Assert.NotEqual(Guid.Empty, target.Id);
+        Assert.Empty(dropped);
+    }
+
+    [Fact]
+    public void TargetsNestedInsideCompoundTreesAreFound()
+    {
+        // The form writes leaves, but the API writes trees. A target buried in
+        // an AND that nobody collects is a badge that never progresses.
+        var badge = new CustomBadge
+        {
+            Name = "Arc completionist",
+            Criteria = new CustomBadgeCriteria
+            {
+                Operator = CompoundOperator.And,
+                Children = new List<CustomBadgeCriteria>
+                {
+                    new() { Metric = AchievementMetric.MoviesWatched, Threshold = 10 },
+                    new()
+                    {
+                        Operator = CompoundOperator.Or,
+                        Children = new List<CustomBadgeCriteria>
+                        {
+                            new()
+                            {
+                                Metric = AchievementMetric.ItemPlayCount,
+                                MetricParameter = Ref("3005"),
+                                Threshold = 3005,
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var targets = ObservedTargets.Collect(new[] { badge }, cap: 50, out _);
+
+        Assert.Single(targets);
+        Assert.Equal("3005", targets[0].Name);
+    }
+
+    [Fact]
+    public void DisabledBadgesAndUntargetedMetricsContributeNothing()
+    {
+        var badges = new[]
+        {
+            Leaf(AchievementMetric.ContainerCompletionPercent, Ref("Hidden"), enabled: false),
+            Leaf(AchievementMetric.MoviesWatched, "not a target"),
+        };
+
+        Assert.Empty(ObservedTargets.Collect(badges, cap: 50, out _));
+    }
+
+    [Fact]
+    public void TheSameTargetReferencedTwiceIsComputedOnce()
+    {
+        // Two badges on the same series (50% and 100%) are the normal way to
+        // build a ladder. Computing that series twice per play is pure waste.
+        var shared = Ref("One Piece");
+        var badges = new[]
+        {
+            Leaf(AchievementMetric.ContainerCompletionPercent, shared),
+            Leaf(AchievementMetric.ContainerCompletionPercent, shared),
+        };
+
+        Assert.Single(ObservedTargets.Collect(badges, cap: 50, out _));
+    }
+
+    [Fact]
+    public void TheCapIsEnforcedAndReportsWhatItDropped()
+    {
+        // A silent cap reads as "everything is covered" when it is not, which
+        // is the worst way for a limit to behave.
+        var badges = Enumerable.Range(0, 5)
+            .Select(i => Leaf(AchievementMetric.ContainerCompletionPercent, Ref("Series " + i)))
+            .ToArray();
+
+        var targets = ObservedTargets.Collect(badges, cap: 3, out var dropped);
+
+        Assert.Equal(3, targets.Count);
+        Assert.Equal(2, dropped.Count);
+    }
+
+    [Fact]
+    public void ANameOnlyTargetIsStillObserved()
+    {
+        // It has no GUID yet, so it reads as zero progress; collecting it is
+        // exactly how it gets resolved and rewritten.
+        var targets = ObservedTargets.Collect(
+            new[] { Leaf(AchievementMetric.ContainerCompletionPercent, "One Piece") },
+            cap: 50,
+            out _);
+
+        var target = Assert.Single(targets);
+        Assert.Equal(Guid.Empty, target.Id);
+        Assert.Equal("One Piece", target.Name);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TargetLivePathTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TargetLivePathTests.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #107. Targeted badges have the same failure shape the discography
+/// badges had before 3c23df4: one writer, reachable only from the watch
+/// history scan, so finishing a series live never moved the badge and the
+/// symptom was a progress bar quietly stuck at its last scanned value. This
+/// pins the dependency that makes the live path reachable at all.
+/// </summary>
+public class TargetLivePathTests
+{
+    [Fact]
+    public void TheTrackerCanReachTheTargetProgressService()
+    {
+        var constructor = typeof(PlaybackCompletionTracker).GetConstructors().Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(TargetProgressService));
+    }
+
+    [Fact]
+    public void TheBackfillCanReachTheTargetProgressService()
+    {
+        // The scan is the reconciler: it is the only pass that recomputes
+        // targets the live path never sees, including every target for a user
+        // who has not played anything since the badge was authored.
+        var constructor = typeof(WatchHistoryBackfillService).GetConstructors().Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(TargetProgressService));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TargetProgressServiceTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TargetProgressServiceTests.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Configuration;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Controller.Library;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #107. Two things are worth pinning here and one is not. The
+/// percentage arithmetic is pure and gets a real test, including the zero
+/// case that would otherwise hand out a badge for an empty container. The
+/// wiring gets a reflection test, the way LibraryCompletionWiringTests pins
+/// the backfill: a dependency silently dropped from the constructor is how
+/// this codebase has produced quietly-stuck badges twice before. Exercising
+/// the queries themselves needs a live library, so that evidence belongs in
+/// the PR as a recorded run, not in a mock here.
+/// </summary>
+public class TargetProgressServiceTests
+{
+    [Fact]
+    public void AnEmptyContainerIsNotComplete()
+    {
+        // Zero of zero reads as 100 in any naive percentage, which would hand
+        // out "you finished it" for an empty collection. LibraryCompletion
+        // already skips on total == 0 for the same reason.
+        Assert.Null(TargetProgressService.Percent(total: 0, played: 0));
+    }
+
+    [Fact]
+    public void PercentagesRoundTheWayTheRestOfThePluginDoes()
+    {
+        Assert.Equal(0, TargetProgressService.Percent(10, 0));
+        Assert.Equal(50, TargetProgressService.Percent(10, 5));
+        Assert.Equal(100, TargetProgressService.Percent(10, 10));
+        // 1 of 3 is 33.33, rounds to 33; 2 of 3 is 66.67, rounds to 67.
+        Assert.Equal(33, TargetProgressService.Percent(3, 1));
+        Assert.Equal(67, TargetProgressService.Percent(3, 2));
+    }
+
+    [Fact]
+    public void ASingleItemContainerCanReachOneHundred()
+    {
+        // Deliberately different from ArtistCompletionPercent, which skips
+        // one-track artists because it computes every artist automatically.
+        // Targets are chosen by hand, so a one-item target is a choice.
+        Assert.Equal(100, TargetProgressService.Percent(1, 1));
+    }
+
+    [Fact]
+    public void TheServiceCanReachTheLibraryAndTheUserData()
+    {
+        // Play count comes from Jellyfin's own UserItemData, which is what
+        // makes "play this 3005 times" work against history that already
+        // exists. Losing IUserDataManager here would silently reduce the
+        // metric to zero for everyone.
+        var constructor = typeof(TargetProgressService).GetConstructors().Single();
+        var parameterTypes = constructor.GetParameters().Select(p => p.ParameterType).ToArray();
+
+        Assert.Contains(typeof(ILibraryManager), parameterTypes);
+        Assert.Contains(typeof(IUserDataManager), parameterTypes);
+        Assert.Contains(typeof(CustomBadgeService), parameterTypes);
+        Assert.Contains(typeof(AchievementBadgeService), parameterTypes);
+    }
+
+    [Fact]
+    public void TheTargetCapHasASaneDefault()
+    {
+        Assert.Equal(50, new PluginConfiguration().MaxTargetedBadgeTargets);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TargetRefTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TargetRefTests.cs
@@ -1,0 +1,72 @@
+using System;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #107. The target parameter carries both halves of an identity: the
+/// GUID, which survives a rename, and the name, which survives a delete and
+/// re-add. These pin the parsing, including the case that bites first: a
+/// display name that itself contains the separator.
+/// </summary>
+public class TargetRefTests
+{
+    private static readonly Guid Target = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public void FormatAndParseRoundTrip()
+    {
+        var raw = TargetRef.Format(Target, "One Piece");
+
+        Assert.True(TargetRef.TryParse(raw, out var id, out var name));
+        Assert.Equal(Target, id);
+        Assert.Equal("One Piece", name);
+        Assert.Equal(Target.ToString("N"), TargetRef.KeyOf(raw));
+    }
+
+    [Fact]
+    public void ANameWrittenByHandParsesWithNoGuid()
+    {
+        // Admins can POST criteria straight to the API, and the docs show
+        // name-shaped parameters for the older metrics. A bare name must not
+        // throw; it resolves later, and KeyOf reports "not resolved yet".
+        Assert.True(TargetRef.TryParse("One Piece", out var id, out var name));
+        Assert.Equal(Guid.Empty, id);
+        Assert.Equal("One Piece", name);
+        Assert.Null(TargetRef.KeyOf("One Piece"));
+    }
+
+    [Fact]
+    public void TheSeparatorInsideADisplayNameSurvives()
+    {
+        // Real library titles contain pipes. Splitting on the last separator,
+        // or on all of them, truncates the name and breaks the fallback lookup
+        // exactly when it is needed.
+        var raw = TargetRef.Format(Target, "Rock | Roll: Live");
+
+        Assert.True(TargetRef.TryParse(raw, out var id, out var name));
+        Assert.Equal(Target, id);
+        Assert.Equal("Rock | Roll: Live", name);
+    }
+
+    [Fact]
+    public void EmptyInputIsRejected()
+    {
+        Assert.False(TargetRef.TryParse(null, out _, out _));
+        Assert.False(TargetRef.TryParse("   ", out _, out _));
+        Assert.Null(TargetRef.KeyOf(null));
+    }
+
+    [Fact]
+    public void DashedGuidsAreAcceptedToo()
+    {
+        // The picker writes "N", but a hand-written parameter may paste the
+        // dashed form straight out of the Jellyfin URL bar.
+        var raw = Target.ToString("D") + "|One Piece";
+
+        Assert.True(TargetRef.TryParse(raw, out var id, out _));
+        Assert.Equal(Target, id);
+        Assert.Equal(Target.ToString("N"), TargetRef.KeyOf(raw));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TargetSeedingTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TargetSeedingTests.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Jellyfin.Plugin.AchievementBadges.Api;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #107. A targeted badge authored today has to count the history a
+/// user already has, or it reads zero until someone runs a scan. That is the
+/// same complaint issue #24 raised about "Sampler", and the fix is the same
+/// shape: give the write path a way to reach the recompute.
+/// </summary>
+public class TargetSeedingTests
+{
+    [Fact]
+    public void TheCustomBadgeControllerCanReachTheRecompute()
+    {
+        var constructor = typeof(CustomBadgesController).GetConstructors().Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(TargetProgressService));
+    }
+
+    [Fact]
+    public void TheRecomputeEndpointCanReachTargets()
+    {
+        // The endpoint exists precisely so a broken or unwanted scan does not
+        // leave the percentages unreachable, which is why 3c23df4 extended it
+        // for artists. Targets need the same escape hatch.
+        var constructor = typeof(AchievementBadgesController).GetConstructors().Single();
+
+        Assert.Contains(
+            constructor.GetParameters(),
+            p => p.ParameterType == typeof(TargetProgressService));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TargetedBadgeValidationTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TargetedBadgeValidationTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #107. A targeted metric with no target can never unlock, and it
+/// fails silently: the badge renders, sits at zero, and nothing logs. Reject
+/// it at write time, where the admin is still looking at the form.
+/// </summary>
+public class TargetedBadgeValidationTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly CustomBadgeService _service;
+
+    public TargetedBadgeValidationTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "abvalid_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var paths = new Mock<IApplicationPaths>();
+        paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        _service = new CustomBadgeService(paths.Object, NullLogger<CustomBadgeService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private static CustomBadge BadgeWith(AchievementMetric metric, string? parameter)
+    {
+        return new CustomBadge
+        {
+            Name = "Alabasta",
+            Criteria = new CustomBadgeCriteria
+            {
+                Metric = metric,
+                MetricParameter = parameter,
+                Threshold = 100,
+            },
+        };
+    }
+
+    [Fact]
+    public void ATargetedBadgeWithoutATargetIsRejected()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => _service.Upsert(BadgeWith(AchievementMetric.ContainerCompletionPercent, null)));
+        Assert.Contains("target", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Throws<ArgumentException>(
+            () => _service.Upsert(BadgeWith(AchievementMetric.ItemPlayCount, "   ")));
+    }
+
+    [Fact]
+    public void ATargetedBadgeInsideACompoundTreeIsCheckedToo()
+    {
+        // The form only writes leaves, but the API accepts whole trees, and an
+        // unreachable leaf buried in an AND is worse than a broken top-level
+        // badge: the whole compound silently never fires.
+        var badge = new CustomBadge
+        {
+            Name = "Arc completionist",
+            Criteria = new CustomBadgeCriteria
+            {
+                Operator = CompoundOperator.And,
+                Children = new List<CustomBadgeCriteria>
+                {
+                    new() { Metric = AchievementMetric.MoviesWatched, Threshold = 10 },
+                    new() { Metric = AchievementMetric.ContainerCompletionPercent, Threshold = 100 },
+                },
+            },
+        };
+
+        Assert.Throws<ArgumentException>(() => _service.Upsert(badge));
+    }
+
+    [Fact]
+    public void ATargetedBadgeWithATargetIsAccepted()
+    {
+        var raw = Guid.NewGuid().ToString("N") + "|One Piece";
+        var saved = _service.Upsert(BadgeWith(AchievementMetric.ContainerCompletionPercent, raw));
+
+        Assert.Equal(raw, saved.Criteria.MetricParameter);
+    }
+
+    [Fact]
+    public void ANameOnlyTargetIsAccepted()
+    {
+        // Authored through the API before any GUID exists. It resolves on the
+        // first recompute; rejecting it would break the documented workflow of
+        // POSTing criteria by hand.
+        var saved = _service.Upsert(BadgeWith(AchievementMetric.ItemPlayCount, "3005"));
+
+        Assert.Equal("3005", saved.Criteria.MetricParameter);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TargetedMetricTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TargetedMetricTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #107. Targeted metrics read a per-target dictionary keyed by the
+/// target's GUID, the same shape LibraryCompletionPercents and
+/// ArtistCompletionPercents already use. These pin the two behaviours that
+/// the artist path had to learn the hard way: the scoped writer merges rather
+/// than replaces, and an unresolved parameter reads as zero instead of
+/// throwing.
+/// </summary>
+public class TargetedMetricTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly AchievementBadgeService _badges;
+
+    private static readonly Guid Viewer = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid SeriesTarget = Guid.Parse("aaaaaaaa-1111-2222-3333-444444444444");
+    private static readonly Guid OtherTarget = Guid.Parse("bbbbbbbb-1111-2222-3333-444444444444");
+
+    private string ViewerId => Viewer.ToString("D");
+
+    public TargetedMetricTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "abtarget_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var paths = new Mock<IApplicationPaths>();
+        paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        var users = new Mock<IUserManager>();
+        users.Setup(m => m.GetUserById(Viewer)).Returns(new User("Viewer", "prov", "reset"));
+
+        _badges = new AchievementBadgeService(
+            paths.Object,
+            users.Object,
+            new WebhookNotifier(NullLogger<WebhookNotifier>.Instance),
+            new AuditLogService(paths.Object, NullLogger<AuditLogService>.Instance),
+            NullLogger<AchievementBadgeService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void TheNewMetricsAreAppendedAtTheEndOfTheEnum()
+    {
+        // Ordinals are serialized. Inserting these anywhere but the end
+        // silently reinterprets every stored badge definition past the
+        // insertion point.
+        var values = (AchievementMetric[])Enum.GetValues(typeof(AchievementMetric));
+
+        Assert.Equal(AchievementMetric.ItemPlayCount, values[^1]);
+        Assert.Equal(AchievementMetric.ContainerCompletionPercent, values[^2]);
+        Assert.Equal(AchievementMetric.ArtistCompletionPercent, values[^3]);
+    }
+
+    [Fact]
+    public void PercentagesRoundTripThroughTheCounters()
+    {
+        var counters = new UserAchievementCounters();
+        Assert.Empty(counters.ContainerCompletionPercents);
+        Assert.Empty(counters.ItemPlayCounts);
+
+        counters.ContainerCompletionPercents[SeriesTarget.ToString("N")] = 100;
+        counters.ItemPlayCounts[OtherTarget.ToString("N")] = 3005;
+
+        Assert.Equal(100, counters.ContainerCompletionPercents[SeriesTarget.ToString("N")]);
+        Assert.Equal(3005, counters.ItemPlayCounts[OtherTarget.ToString("N")]);
+    }
+
+    [Fact]
+    public void MergePreservesTargetsItWasNotAskedAbout()
+    {
+        // The exact defect replace semantics would cause: finish one episode
+        // of one series, lose the percentage the last scan computed for every
+        // other target.
+        _badges.MergeContainerCompletionPercents(ViewerId, new Dictionary<string, int>
+        {
+            [SeriesTarget.ToString("N")] = 40,
+            [OtherTarget.ToString("N")] = 90,
+        });
+
+        _badges.MergeContainerCompletionPercents(ViewerId, new Dictionary<string, int>
+        {
+            [SeriesTarget.ToString("N")] = 60,
+        });
+
+        var counters = _badges.PeekProfile(ViewerId)!.Counters;
+        Assert.Equal(60, counters.ContainerCompletionPercents[SeriesTarget.ToString("N")]);
+        Assert.Equal(90, counters.ContainerCompletionPercents[OtherTarget.ToString("N")]);
+    }
+
+    [Fact]
+    public void MergingNothingDoesNotDisturbStoredProgress()
+    {
+        _badges.MergeItemPlayCounts(ViewerId, new Dictionary<string, int>
+        {
+            [OtherTarget.ToString("N")] = 12,
+        });
+
+        _badges.MergeItemPlayCounts(ViewerId, new Dictionary<string, int>());
+
+        Assert.Equal(12, _badges.PeekProfile(ViewerId)!.Counters.ItemPlayCounts[OtherTarget.ToString("N")]);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -35,6 +35,7 @@ public class AchievementBadgesController : ControllerBase
     private readonly PlaybackCompletionService _playbackCompletionService;
     private readonly WatchHistoryBackfillService _backfillService;
     private readonly LibraryCompletionService _libraryCompletionService;
+    private readonly TargetProgressService _targetProgress;
     private readonly RecapService _recapService;
     private readonly RecommendationService _recommendationService;
     private readonly QuestService _questService;
@@ -61,8 +62,10 @@ public class AchievementBadgesController : ControllerBase
         FriendsService friendsService,
         MessagingService messagingService,
         PowerUpService powerUps,
-        ShopService shop)
+        ShopService shop,
+        TargetProgressService targetProgress)
     {
+        _targetProgress = targetProgress;
         _badgeService = badgeService;
         _playbackCompletionService = playbackCompletionService;
         _backfillService = backfillService;
@@ -1119,7 +1122,15 @@ public class AchievementBadgesController : ControllerBase
         // the watch history scan, so a broken or undesired scan left no way
         // to refresh them at all.
         var artists = _libraryCompletionService.RecomputeArtistsForUser(guid);
-        return Ok(new { LibraryCompletionPercents = result, ArtistCompletionPercents = artists });
+        // [issue #107] Same escape hatch for targeted badges.
+        var targets = _targetProgress.RecomputeForUser(guid);
+        return Ok(new
+        {
+            LibraryCompletionPercents = result,
+            ArtistCompletionPercents = artists,
+            ContainerCompletionPercents = targets.ContainerPercents,
+            ItemPlayCounts = targets.PlayCounts,
+        });
     }
 
     [HttpGet("users/{userId}/library-completion")]

--- a/Jellyfin.Plugin.AchievementBadges/Api/CustomBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/CustomBadgesController.cs
@@ -28,12 +28,54 @@ public class CustomBadgesController : ControllerBase
     private readonly CustomBadgeService _customBadges;
     private readonly AuditLogService _auditLog;
     private readonly AchievementBadgeService _badges;
+    private readonly TargetProgressService _targetProgress;
 
-    public CustomBadgesController(CustomBadgeService customBadges, AuditLogService auditLog, AchievementBadgeService badges)
+    public CustomBadgesController(
+        CustomBadgeService customBadges,
+        AuditLogService auditLog,
+        AchievementBadgeService badges,
+        TargetProgressService targetProgress)
     {
         _customBadges = customBadges;
         _auditLog = auditLog;
         _badges = badges;
+        _targetProgress = targetProgress;
+    }
+
+    /// <summary>
+    /// [issue #107] Recompute every user's progress for the targets this badge
+    /// references, so a badge authored today is retroactive against history
+    /// that already exists. Without it a targeted badge reads zero until the
+    /// next watch history scan, even for a user who finished the series last
+    /// year, which is the complaint issue #24 raised about "Sampler".
+    /// <para>
+    /// Failure is logged by the service and swallowed here: a badge that saved
+    /// correctly must not report an error because one library was unreadable
+    /// during seeding.
+    /// </para>
+    /// </summary>
+    private void SeedTargets(CustomBadge saved)
+    {
+        if (saved?.Criteria is null)
+        {
+            return;
+        }
+
+        var referenced = Helpers.ObservedTargets.Collect(
+            new[] { saved },
+            Plugin.Instance?.Configuration?.MaxTargetedBadgeTargets ?? 50,
+            out _);
+
+        if (referenced.Count == 0)
+        {
+            return;
+        }
+
+        // Full pass rather than one scoped to this badge's targets. Badge
+        // creation is a rare admin action, the full pass is the reconciler
+        // anyway, and scoping it would need a second entry point whose only
+        // caller is this line.
+        _targetProgress.RecomputeAll();
     }
 
     [HttpGet]
@@ -59,6 +101,7 @@ public class CustomBadgesController : ControllerBase
             badge.CreatedAt = DateTimeOffset.UtcNow;
             badge.Id = Guid.NewGuid().ToString("N");
             var saved = _customBadges.Upsert(badge);
+            SeedTargets(saved);
             _auditLog.Log(badge.CreatedBy, badge.CreatedBy, "custom_badge_created",
                 System.Text.Json.JsonSerializer.Serialize(new
                 {
@@ -88,6 +131,7 @@ public class CustomBadgesController : ControllerBase
         {
             badge.Id = id;
             var saved = _customBadges.Upsert(badge);
+            SeedTargets(saved);
             var editor = User?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
             _auditLog.Log(editor, editor, "custom_badge_updated",
                 System.Text.Json.JsonSerializer.Serialize(new

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
@@ -215,4 +215,13 @@ public class PluginConfiguration : BasePluginConfiguration
     // to one entry per user per hour so a single burst doesn't spam.
     public bool EnableSuspiciousActivityFlag { get; set; } = true;
     public int SuspiciousRatePerHour { get; set; } = 30;
+
+    /// <summary>
+    /// [issue #107] Ceiling on how many distinct targets the targeted badges
+    /// may reference. Each target costs one membership check per played item,
+    /// so an unbounded set would turn every play into a library sweep. Targets
+    /// past the cap are ignored and named in the log rather than dropped
+    /// silently.
+    /// </summary>
+    public int MaxTargetedBadgeTargets { get; set; } = 50;
 }

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
@@ -384,12 +384,23 @@
                                 <option value="GenreItemsWatched" data-param="genre">Items watched of a genre&hellip;</option>
                                 <option value="UniqueLanguagesWatched">Unique languages watched</option>
                                 <option value="UniqueCountriesWatched">Unique countries watched</option>
+                                <option value="ContainerCompletionPercent" data-param="target" data-target-kinds="Series,Season,BoxSet,Playlist,MusicAlbum">Completion of one series, season or collection&hellip;</option>
+                                <option value="ItemPlayCount" data-param="target" data-target-kinds="Movie,Episode,Audio,Book">Plays of one specific item&hellip;</option>
                             </select>
                         </div>
                         <div class="inputContainer" id="NewBadgeParamRow" style="display:none;">
                             <label class="inputLabel" for="NewBadgeParam">Genre filter</label>
                             <input type="text" id="NewBadgeParam" is="emby-input" placeholder="e.g. Disco" />
                             <div class="fieldDescription" style="color:rgba(255,255,255,.5);font-size:.85em;margin-top:.2em;">The genre to filter by (case-insensitive) &mdash; must match how it's tagged in your library.</div>
+                            <div id="NewBadgeTargetPicker" style="display:none;">
+                                <label class="inputLabel" for="NewBadgeTargetSearch">Search the library</label>
+                                <input type="text" id="NewBadgeTargetSearch" is="emby-input" placeholder="e.g. One Piece" />
+                                <label class="inputLabel" for="NewBadgeTargetResults" style="margin-top:.4em;">Target</label>
+                                <select id="NewBadgeTargetResults" is="emby-select">
+                                    <option value="">Type to search&hellip;</option>
+                                </select>
+                                <div class="fieldDescription" style="color:rgba(255,255,255,.5);font-size:.85em;margin-top:.2em;">Collections and playlists cover arbitrary groupings, for example one story arc.</div>
+                            </div>
                         </div>
                         <div class="inputContainer">
                             <label class="inputLabel" for="NewBadgeThreshold">Threshold</label>
@@ -526,6 +537,49 @@
 
                 userName: function (user) {
                     return user.Name || user.Username || user.UserName || user.ServerName || user.Id || 'Unknown';
+                },
+
+                // [issue #107] Library search behind the targeted-badge picker.
+                // The option value is the "{guid}|{name}" pair the server
+                // stores: the GUID survives a rename, the name survives an item
+                // being deleted and re-added, and each covers the other.
+                searchBadgeTargets: function (term, kinds) {
+                    var results = document.getElementById('NewBadgeTargetResults');
+                    if (!results) return Promise.resolve([]);
+                    if (!term || term.length < 2) {
+                        results.innerHTML = '<option value="">Type to search&hellip;</option>';
+                        return Promise.resolve([]);
+                    }
+
+                    var query = 'Items?Recursive=true&Limit=25&SearchTerm='
+                        + encodeURIComponent(term)
+                        + '&IncludeItemTypes=' + encodeURIComponent(kinds);
+
+                    return fetch(this.getApiUrl(query), {
+                        headers: this.getAuthHeaders(),
+                        credentials: 'include'
+                    }).then(function (response) {
+                        if (!response.ok) throw new Error('Request failed: ' + response.status);
+                        return response.json();
+                    }).then(function (payload) {
+                        var items = (payload && payload.Items) || [];
+                        if (!items.length) {
+                            results.innerHTML = '<option value="">No match</option>';
+                            return [];
+                        }
+                        results.innerHTML = items.map(function (item) {
+                            var id = String(item.Id || '').replace(/-/g, '');
+                            var label = item.Name
+                                + (item.ProductionYear ? ' (' + item.ProductionYear + ')' : '')
+                                + ' [' + item.Type + ']';
+                            return '<option value="' + escapeAttr(id + '|' + item.Name) + '">'
+                                + escapeHtml(label) + '</option>';
+                        }).join('');
+                        return items;
+                    }).catch(function () {
+                        results.innerHTML = '<option value="">Search failed</option>';
+                        return [];
+                    });
                 },
 
                 loadUsers: function () {
@@ -843,11 +897,22 @@
                     // metrics require one (e.g. "play 50 tracks of genre Disco").
                     var metricOpt = metricEl.options[metricEl.selectedIndex];
                     var needsParam = !!(metricOpt && metricOpt.getAttribute('data-param'));
-                    var metricParam = (document.getElementById('NewBadgeParam').value || '').trim();
+                    // [issue #107] Targeted metrics take their parameter from
+                    // the library picker instead of the free-text field, since
+                    // the value is a guid|name pair nobody should be typing.
+                    var isTarget = !!(metricOpt && metricOpt.getAttribute('data-param') === 'target');
+                    var metricParam = isTarget
+                        ? ((document.getElementById('NewBadgeTargetResults') || {}).value || '')
+                        : ((document.getElementById('NewBadgeParam').value || '').trim());
 
                     if (!name) { status.textContent = 'Name required.'; return; }
                     if (!threshold || threshold < 1) { status.textContent = 'Threshold must be a positive integer.'; return; }
-                    if (needsParam && !metricParam) { status.textContent = 'This metric needs a genre filter value (e.g. Disco).'; return; }
+                    if (needsParam && !metricParam) {
+                        status.textContent = isTarget
+                            ? 'Pick a target from the library first.'
+                            : 'This metric needs a genre filter value (e.g. Disco).';
+                        return;
+                    }
 
                     var criteria = { Metric: metric, Threshold: threshold };
                     if (needsParam) { criteria.MetricParameter = metricParam; }
@@ -880,6 +945,13 @@
                         document.getElementById('NewBadgeDescription').value = '';
                         document.getElementById('NewBadgeIconUrl').value = '';
                         document.getElementById('NewBadgeParam').value = '';
+                        // [issue #107] Clear the picker too, otherwise the next
+                        // badge silently inherits the last target and an admin
+                        // building a ladder creates two badges on one series.
+                        var targetSearch = document.getElementById('NewBadgeTargetSearch');
+                        var targetResults = document.getElementById('NewBadgeTargetResults');
+                        if (targetSearch) { targetSearch.value = ''; }
+                        if (targetResults) { targetResults.innerHTML = '<option value="">Type to search&hellip;</option>'; }
                         AchievementBadgesConfig.loadCustomBadges();
                     }).catch(function (e) {
                         status.textContent = 'Failed: ' + (e.message || e);
@@ -992,14 +1064,54 @@
 
             // [issue #24] Show the genre-filter field only for parametrized
             // metrics (those with a data-param option attribute).
+            // [issue #107] data-param="target" swaps the free-text field for
+            // the library picker, because the target parameter is a guid|name
+            // pair that nobody should be typing by hand.
             function toggleBadgeParamRow() {
                 var el = document.getElementById('NewBadgeMetric');
                 if (!el) return;
                 var opt = el.options[el.selectedIndex];
-                var needs = !!(opt && opt.getAttribute('data-param'));
+                var param = opt && opt.getAttribute('data-param');
+                var needs = !!param;
+                var isTarget = param === 'target';
+
                 var row = document.getElementById('NewBadgeParamRow');
                 if (row) { row.style.display = needs ? '' : 'none'; }
-                if (!needs) { var p = document.getElementById('NewBadgeParam'); if (p) { p.value = ''; } }
+
+                var picker = document.getElementById('NewBadgeTargetPicker');
+                if (picker) { picker.style.display = isTarget ? '' : 'none'; }
+
+                // The genre field and its description belong to the other
+                // parametrized metrics; hide both when the picker is showing,
+                // or the form asks for a genre and a target at once.
+                var label = row ? row.querySelector('label[for="NewBadgeParam"]') : null;
+                var desc = row ? row.querySelector('.fieldDescription') : null;
+                if (label) { label.style.display = isTarget ? 'none' : ''; }
+                if (desc) { desc.style.display = isTarget ? 'none' : ''; }
+
+                var text = document.getElementById('NewBadgeParam');
+                if (text) {
+                    text.style.display = isTarget ? 'none' : '';
+                    if (!needs || isTarget) { text.value = ''; }
+                }
+
+                var search = document.getElementById('NewBadgeTargetSearch');
+                var results = document.getElementById('NewBadgeTargetResults');
+                if (!isTarget) {
+                    if (search) { search.value = ''; }
+                    if (results) { results.innerHTML = '<option value="">Type to search&hellip;</option>'; }
+                    return;
+                }
+
+                if (search && !search._abTargetWired) {
+                    search._abTargetWired = true;
+                    search.addEventListener('input', function () {
+                        var current = document.getElementById('NewBadgeMetric');
+                        var currentOpt = current.options[current.selectedIndex];
+                        var kinds = (currentOpt && currentOpt.getAttribute('data-target-kinds')) || '';
+                        AchievementBadgesConfig.searchBadgeTargets(search.value.trim(), kinds);
+                    });
+                }
             }
 
             document.querySelector('#AchievementBadgesConfigPage')

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/ObservedTargets.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/ObservedTargets.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// [issue #107] One target a badge points at, after parsing.
+/// </summary>
+/// <param name="Metric">Which targeted metric referenced it.</param>
+/// <param name="Parameter">The raw MetricParameter, kept so the resolver can
+/// rewrite it in place when the name lookup wins over a stale GUID.</param>
+/// <param name="Id">Target GUID, or Guid.Empty when the badge was authored by
+/// name and has not been resolved yet.</param>
+/// <param name="Name">Display name, used as the fallback lookup key.</param>
+public sealed record ObservedTarget(AchievementMetric Metric, string Parameter, Guid Id, string Name);
+
+/// <summary>
+/// [issue #107] Collects the targets that enabled custom badges reference.
+/// <para>
+/// This walk is what bounds the whole feature's cost. Container completion
+/// has no natural aggregate question behind it ("how many containers did this
+/// user finish" is not a badge anyone asked for), so without it the metric
+/// would imply sweeping every series, season, collection and playlist on the
+/// server. With it, the work is proportional to what an admin authored.
+/// </para>
+/// </summary>
+public static class ObservedTargets
+{
+    public static bool IsTargeted(AchievementMetric metric)
+    {
+        return metric is AchievementMetric.ContainerCompletionPercent
+            or AchievementMetric.ItemPlayCount;
+    }
+
+    public static IReadOnlyList<ObservedTarget> Collect(
+        IEnumerable<CustomBadge> badges,
+        int cap,
+        out IReadOnlyList<string> dropped)
+    {
+        var found = new List<ObservedTarget>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var overflow = new List<string>();
+
+        if (badges is not null)
+        {
+            foreach (var badge in badges)
+            {
+                if (badge is null || !badge.Enabled || badge.Criteria is null)
+                {
+                    continue;
+                }
+
+                Walk(badge.Criteria, depth: 1, found, seen, overflow, cap);
+            }
+        }
+
+        dropped = overflow;
+        return found;
+    }
+
+    private static void Walk(
+        CustomBadgeCriteria node,
+        int depth,
+        List<ObservedTarget> found,
+        HashSet<string> seen,
+        List<string> overflow,
+        int cap)
+    {
+        // Depth is already bounded at write time by CustomBadgeService, but a
+        // definition file edited by hand reaches this walk without passing
+        // through Upsert.
+        if (node is null || depth > CustomBadgeService.MaxCriteriaDepth)
+        {
+            return;
+        }
+
+        if (node.Children is { Count: > 0 })
+        {
+            foreach (var child in node.Children)
+            {
+                Walk(child, depth + 1, found, seen, overflow, cap);
+            }
+
+            return;
+        }
+
+        if (node.Metric is not { } metric || !IsTargeted(metric))
+        {
+            return;
+        }
+
+        if (!TargetRef.TryParse(node.MetricParameter, out var id, out var name)
+            || string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        var key = metric + " " + (id != Guid.Empty ? id.ToString("N") : name);
+        if (!seen.Add(key))
+        {
+            return;
+        }
+
+        if (found.Count >= cap)
+        {
+            // Named rather than counted: a silent cap reads as full coverage.
+            overflow.Add(name);
+            return;
+        }
+
+        found.Add(new ObservedTarget(metric, node.MetricParameter ?? name, id, name));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/TargetRef.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/TargetRef.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// [issue #107] Identity of a targeted badge's subject, carried in
+/// <c>MetricParameter</c> as <c>"{guid:N}|{display name}"</c>.
+/// <para>
+/// Both halves are stored because each covers the other's failure mode. A
+/// GUID does not survive an item being deleted and re-added, which is routine
+/// after a mass rename upstream of Jellyfin; a name does not survive a rename
+/// and is ambiguous across same-titled items. Resolution tries the GUID, then
+/// the name, and rewrites the GUID when the name wins.
+/// </para>
+/// <para>
+/// The split is on the FIRST separator, so a display name containing a pipe
+/// keeps it. Splitting on the last one would truncate the name and break the
+/// fallback lookup precisely when the GUID has already gone stale.
+/// </para>
+/// </summary>
+public static class TargetRef
+{
+    public const char Separator = '|';
+
+    public static string Format(Guid id, string? name)
+    {
+        return id.ToString("N") + Separator + (name ?? string.Empty);
+    }
+
+    public static bool TryParse(string? raw, out Guid id, out string name)
+    {
+        id = Guid.Empty;
+        name = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        var trimmed = raw.Trim();
+        var cut = trimmed.IndexOf(Separator);
+        if (cut < 0)
+        {
+            name = trimmed;
+            return true;
+        }
+
+        var head = trimmed.Substring(0, cut);
+        var tail = trimmed.Substring(cut + 1);
+
+        if (Guid.TryParse(head, out var parsed))
+        {
+            id = parsed;
+            name = tail;
+        }
+        else
+        {
+            // Not a GUID in front: the whole value is a name that happens to
+            // contain the separator.
+            name = trimmed;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Counter-dictionary key for this parameter, or null when the parameter
+    /// has no GUID yet. Null means "not resolved", which reads as zero
+    /// progress rather than as an error: the next recompute resolves the name
+    /// and rewrites the parameter with its GUID.
+    /// </summary>
+    public static string? KeyOf(string? raw)
+    {
+        return TryParse(raw, out var id, out _) && id != Guid.Empty
+            ? id.ToString("N")
+            : null;
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Models/AchievementMetric.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/AchievementMetric.cs
@@ -92,4 +92,14 @@ public enum AchievementMetric
     // when no MetricParameter is set. Appended at the end for the same reason
     // as the two above: existing serialized ordinals must not shift.
     ArtistCompletionPercent,
+
+    // [issue #107] Targeted metrics. MetricParameter carries "{guid:N}|{name}"
+    // (see Helpers/TargetRef). ContainerCompletionPercent is played leaves over
+    // total leaves of one series, season, collection, playlist or album;
+    // ItemPlayCount is Jellyfin's own play count for one item, which is what
+    // makes "play this track 3005 times" evaluate against history that already
+    // exists. Appended at the end for the same reason as the three above:
+    // existing serialized ordinals must not shift.
+    ContainerCompletionPercent,
+    ItemPlayCount,
 }

--- a/Jellyfin.Plugin.AchievementBadges/Models/UserAchievementCounters.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/UserAchievementCounters.cs
@@ -124,6 +124,12 @@ public class UserAchievementCounters
     // named artist or as "your best artist".
     public Dictionary<string, int> ArtistCompletionPercents { get; set; } = new();
 
+    // [issue #107] Per-target progress. Keyed by the target's GUID in "N"
+    // format rather than by the full "guid|name" parameter, so renaming the
+    // series does not orphan the progress already stored for it.
+    public Dictionary<string, int> ContainerCompletionPercents { get; set; } = new();
+    public Dictionary<string, int> ItemPlayCounts { get; set; } = new();
+
     // Per-decade item counts (key = decade as string, e.g. "1970", "1980")
     public Dictionary<string, int> DecadeItemCounts { get; set; } = new();
     // Per-day-of-week item counts (key = day name, e.g. "Monday")

--- a/Jellyfin.Plugin.AchievementBadges/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.AchievementBadges/PluginServiceRegistrator.cs
@@ -60,6 +60,11 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
                     "watch-carry.json"));
         });
         serviceCollection.AddSingleton<LibraryCompletionService>();
+        // [issue #107] Targeted badge progress: completion of one series,
+        // season, collection, playlist or album, and play count of one item.
+        // Separate from LibraryCompletionService because it is bounded by the
+        // badges that reference a target rather than by the library.
+        serviceCollection.AddSingleton<TargetProgressService>();
         serviceCollection.AddSingleton<RecapService>();
         serviceCollection.AddSingleton<RecommendationService>();
         serviceCollection.AddSingleton<QuestService>();

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -1274,6 +1274,50 @@ public class AchievementBadgeService : IDisposable
         }
     }
 
+    /// <summary>
+    /// [issue #107] Merge variant for the live path, which recomputes only the
+    /// targets containing the item whose played flag just changed. Replace
+    /// semantics here would wipe every other target's progress on each play,
+    /// which is the defect fixed for artists in 3c23df4.
+    /// </summary>
+    public void MergeContainerCompletionPercents(string userId, Dictionary<string, int> percents)
+    {
+        MergeTargetMap(userId, percents, static c => c.ContainerCompletionPercents);
+    }
+
+    /// <summary>
+    /// [issue #107] Same merge contract as the container map above.
+    /// </summary>
+    public void MergeItemPlayCounts(string userId, Dictionary<string, int> counts)
+    {
+        MergeTargetMap(userId, counts, static c => c.ItemPlayCounts);
+    }
+
+    private void MergeTargetMap(
+        string userId,
+        Dictionary<string, int> values,
+        Func<UserAchievementCounters, Dictionary<string, int>> selector)
+    {
+        if (values is null || values.Count == 0)
+        {
+            return;
+        }
+
+        userId = NormalizeUserId(userId);
+        lock (_lock)
+        {
+            var profile = GetOrCreateProfile(userId);
+            var map = selector(profile.Counters);
+            foreach (var kv in values)
+            {
+                map[kv.Key] = kv.Value;
+            }
+
+            EvaluateBadges(profile, userId);
+            Save();
+        }
+    }
+
     public void RegisterLogin(string userId)
     {
         userId = NormalizeUserId(userId);
@@ -3175,6 +3219,27 @@ public class AchievementBadgeService : IDisposable
                 return counters.ArtistCompletionPercents.TryGetValue(parameter, out var a) ? a : 0;
             }
             return counters.BestArtistCompletionPercent;
+        }
+
+        // [issue #107] Targeted metrics. A parameter with no GUID yet reads as
+        // zero rather than throwing: the badge was authored by name and the
+        // next recompute resolves it and rewrites the parameter.
+        if (metric == AchievementMetric.ContainerCompletionPercent)
+        {
+            var containerKey = Helpers.TargetRef.KeyOf(parameter);
+            return containerKey is not null
+                && counters.ContainerCompletionPercents.TryGetValue(containerKey, out var pct)
+                ? pct
+                : 0;
+        }
+
+        if (metric == AchievementMetric.ItemPlayCount)
+        {
+            var itemKey = Helpers.TargetRef.KeyOf(parameter);
+            return itemKey is not null
+                && counters.ItemPlayCounts.TryGetValue(itemKey, out var plays)
+                ? plays
+                : 0;
         }
 
         return GetSingleMetricValue(counters, metric);

--- a/Jellyfin.Plugin.AchievementBadges/Services/CustomBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/CustomBadgeService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Jellyfin.Plugin.AchievementBadges.Models;
 using MediaBrowser.Common.Configuration;
 using Microsoft.Extensions.Logging;
@@ -196,10 +197,31 @@ public class CustomBadgeService
             throw new ArgumentException("Criteria node must be either leaf (Metric+Threshold) or compound (Operator+Children).");
         if (isLeaf && node.Threshold!.Value < 1)
             throw new ArgumentException("Leaf threshold must be at least 1.");
+
+        // [issue #107] A targeted metric with no target can never unlock, and
+        // it fails silently: the badge renders and sits at zero forever. Reject
+        // it here, while the admin is still looking at the form. A bare name
+        // with no GUID is allowed; it resolves on the first recompute.
+        if (isLeaf && IsTargeted(node.Metric!.Value))
+        {
+            if (!TargetRef.TryParse(node.MetricParameter, out _, out var targetName)
+                || string.IsNullOrWhiteSpace(targetName))
+            {
+                throw new ArgumentException(
+                    "Metric " + node.Metric.Value + " requires a target in MetricParameter.");
+            }
+        }
+
         if (isCompound)
         {
             foreach (var child in node.Children!) ValidateNode(child, depth + 1, ref totalNodeCount);
         }
+    }
+
+    private static bool IsTargeted(AchievementMetric metric)
+    {
+        return metric is AchievementMetric.ContainerCompletionPercent
+            or AchievementMetric.ItemPlayCount;
     }
 
     private void Load()

--- a/Jellyfin.Plugin.AchievementBadges/Services/CustomBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/CustomBadgeService.cs
@@ -202,7 +202,7 @@ public class CustomBadgeService
         // it fails silently: the badge renders and sits at zero forever. Reject
         // it here, while the admin is still looking at the form. A bare name
         // with no GUID is allowed; it resolves on the first recompute.
-        if (isLeaf && IsTargeted(node.Metric!.Value))
+        if (isLeaf && ObservedTargets.IsTargeted(node.Metric!.Value))
         {
             if (!TargetRef.TryParse(node.MetricParameter, out _, out var targetName)
                 || string.IsNullOrWhiteSpace(targetName))
@@ -216,12 +216,6 @@ public class CustomBadgeService
         {
             foreach (var child in node.Children!) ValidateNode(child, depth + 1, ref totalNodeCount);
         }
-    }
-
-    private static bool IsTargeted(AchievementMetric metric)
-    {
-        return metric is AchievementMetric.ContainerCompletionPercent
-            or AchievementMetric.ItemPlayCount;
     }
 
     private void Load()

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -23,6 +23,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
     private readonly IUserDataManager _userDataManager;
     private readonly PlaybackCompletionService _playbackCompletionService;
     private readonly LibraryCompletionService _libraryCompletionService;
+    private readonly TargetProgressService _targetProgress;
     private readonly ILogger<PlaybackCompletionTracker> _logger;
     private bool _subscribed;
     private bool _disposed;
@@ -65,6 +66,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         IUserDataManager userDataManager,
         PlaybackCompletionService playbackCompletionService,
         LibraryCompletionService libraryCompletionService,
+        TargetProgressService targetProgress,
         WatchCarryStore carried,
         ILogger<PlaybackCompletionTracker> logger)
     {
@@ -73,6 +75,7 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         _userDataManager = userDataManager;
         _playbackCompletionService = playbackCompletionService;
         _libraryCompletionService = libraryCompletionService;
+        _targetProgress = targetProgress;
         // Shared rather than owned: the watch history scan credits items too,
         // and it has to be able to drop their carry. While this lived in here
         // the scan could not reach it, so credited items kept their banked
@@ -213,10 +216,51 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
                 // the same way the scan's Audio query excludes them.
                 HandleAudioUserData(e, item, reason);
             }
+
+            // [issue #107] Targeted badges are defined over Jellyfin's own
+            // played flag and play count, so they refresh on the same signal
+            // the two handlers above use, but for every item kind: a targeted
+            // badge can point at a movie, an episode, a track or a book.
+            HandleTargetedUserData(e, item, reason);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "[AchievementBadges] Failed to process UserDataSaved event.");
+        }
+    }
+
+    /// <summary>
+    /// [issue #107] Refresh the targets that contain this item when its played
+    /// flag changes.
+    /// <para>
+    /// TogglePlayed passes in both directions: unmarking an episode changes
+    /// the truthful percentage too, and unlocked badges are never revoked.
+    /// PlaybackFinished fires on every stop, not only on completion, so it is
+    /// gated on Played, otherwise every skipped track would pay for a
+    /// recompute that changes nothing.
+    /// </para>
+    /// <para>
+    /// Using Jellyfin's flag rather than this plugin's own credit decision is
+    /// deliberate: marking a season watched by hand is how an old arc actually
+    /// gets completed, and no playback event fires for that.
+    /// </para>
+    /// </summary>
+    private void HandleTargetedUserData(UserDataSaveEventArgs e, BaseItem item, string reason)
+    {
+        var toggled = reason.Equals("TogglePlayed", StringComparison.OrdinalIgnoreCase);
+        var finishedPlayed = reason.Equals("PlaybackFinished", StringComparison.OrdinalIgnoreCase)
+            && e.UserData?.Played == true;
+        if (!toggled && !finishedPlayed)
+        {
+            return;
+        }
+
+        var result = _targetProgress.RecomputeForItem(e.UserId, item);
+        if (!result.IsEmpty)
+        {
+            _logger.LogDebug(
+                "[AchievementBadges] Target refresh: user={UserId} item={ItemId} reason={Reason} containers={Containers} items={Items}",
+                e.UserId, item.Id, reason, result.ContainerPercents.Count, result.PlayCounts.Count);
         }
     }
 

--- a/Jellyfin.Plugin.AchievementBadges/Services/TargetProgressService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/TargetProgressService.cs
@@ -1,0 +1,399 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AchievementBadges.Services;
+
+/// <summary>[issue #107] One pass of targeted progress for one user.</summary>
+public sealed class TargetProgressResult
+{
+    public Dictionary<string, int> ContainerPercents { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public Dictionary<string, int> PlayCounts { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public bool IsEmpty => ContainerPercents.Count == 0 && PlayCounts.Count == 0;
+}
+
+/// <summary>
+/// [issue #107] Computes the two targeted metrics against the library.
+/// <para>
+/// Kept out of LibraryCompletionService on purpose: that file already carries
+/// two unrelated jobs (library folders and artist discography), and targets
+/// are a third with a different lifecycle.
+/// </para>
+/// <para>
+/// Leaf resolution has two shapes because Jellyfin has two shapes of
+/// container. Series, Season and MusicAlbum are real folders, so their leaves
+/// come from an AncestorIds query. BoxSet and Playlist are Folder subclasses
+/// too, but they hold their members as linked children, which AncestorIds
+/// does not reach, so those go through GetLinkedChildren and expand any
+/// folder member (a whole series dropped into a collection) through the
+/// first path.
+/// </para>
+/// </summary>
+public class TargetProgressService
+{
+    private static readonly BaseItemKind[] LeafKinds =
+    {
+        BaseItemKind.Movie,
+        BaseItemKind.Episode,
+        BaseItemKind.Audio,
+        BaseItemKind.AudioBook,
+        BaseItemKind.Book,
+    };
+
+    private readonly ILibraryManager _libraryManager;
+    private readonly IUserDataManager _userDataManager;
+    private readonly IUserManager _userManager;
+    private readonly CustomBadgeService _customBadges;
+    private readonly AchievementBadgeService _badgeService;
+    private readonly ILogger<TargetProgressService> _logger;
+
+    public TargetProgressService(
+        ILibraryManager libraryManager,
+        IUserDataManager userDataManager,
+        IUserManager userManager,
+        CustomBadgeService customBadges,
+        AchievementBadgeService badgeService,
+        ILogger<TargetProgressService> logger)
+    {
+        _libraryManager = libraryManager;
+        _userDataManager = userDataManager;
+        _userManager = userManager;
+        _customBadges = customBadges;
+        _badgeService = badgeService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Played leaves over total leaves. Null for an empty container: zero of
+    /// zero otherwise reads as complete and hands out the badge for free.
+    /// </summary>
+    public static int? Percent(int total, int played)
+    {
+        if (total <= 0)
+        {
+            return null;
+        }
+
+        return (int)Math.Round(100.0 * played / total);
+    }
+
+    /// <summary>
+    /// Full pass over every observed target. It is the reconciler: the only
+    /// path that recomputes targets the live path never sees.
+    /// </summary>
+    public TargetProgressResult RecomputeForUser(Guid userGuid)
+    {
+        var result = new TargetProgressResult();
+        var user = _userManager.GetUserById(userGuid);
+        if (user is null)
+        {
+            return result;
+        }
+
+        var targets = CollectTargets();
+        if (targets.Count == 0)
+        {
+            return result;
+        }
+
+        try
+        {
+            foreach (var target in targets)
+            {
+                Compute(user, target, result);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Same guard as the library and artist recomputes: a failed
+            // enumeration must not publish a partial map over progress that is
+            // still true.
+            _logger.LogWarning(ex, "[AchievementBadges] Target recompute failed for user {UserId}", userGuid);
+            return new TargetProgressResult();
+        }
+
+        Publish(userGuid, result);
+        return result;
+    }
+
+    /// <summary>
+    /// Scoped pass for the live path: only the targets that contain the item
+    /// whose played flag just changed.
+    /// </summary>
+    public TargetProgressResult RecomputeForItem(Guid userGuid, BaseItem item)
+    {
+        var result = new TargetProgressResult();
+        if (item is null)
+        {
+            return result;
+        }
+
+        var user = _userManager.GetUserById(userGuid);
+        if (user is null)
+        {
+            return result;
+        }
+
+        foreach (var target in CollectTargets())
+        {
+            try
+            {
+                if (!Contains(user, target, item))
+                {
+                    continue;
+                }
+
+                Compute(user, target, result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "[AchievementBadges] Scoped target recompute failed for {Target}", target.Name);
+            }
+        }
+
+        Publish(userGuid, result);
+        return result;
+    }
+
+    public void RecomputeAll()
+    {
+        foreach (var user in _userManager.EnumerateAll())
+        {
+            RecomputeForUser(user.Id);
+        }
+    }
+
+    private IReadOnlyList<ObservedTarget> CollectTargets()
+    {
+        var cap = Plugin.Instance?.Configuration?.MaxTargetedBadgeTargets ?? 50;
+        var targets = ObservedTargets.Collect(_customBadges.GetEnabled(), cap, out var dropped);
+        if (dropped.Count > 0)
+        {
+            _logger.LogWarning(
+                "[AchievementBadges] {Count} badge targets exceed the cap of {Cap} and are not computed: {Names}",
+                dropped.Count, cap, string.Join(", ", dropped));
+        }
+
+        return targets;
+    }
+
+    /// <summary>
+    /// Both writers merge. The maps are keyed by target, and a pass that only
+    /// looked at one target must not erase the rest: replacing from the scoped
+    /// path is the defect fixed for artists in 3c23df4.
+    /// </summary>
+    private void Publish(Guid userGuid, TargetProgressResult result)
+    {
+        if (result.IsEmpty)
+        {
+            return;
+        }
+
+        var userId = userGuid.ToString("D");
+        _badgeService.MergeContainerCompletionPercents(userId, result.ContainerPercents);
+        _badgeService.MergeItemPlayCounts(userId, result.PlayCounts);
+    }
+
+    private void Compute(User user, ObservedTarget target, TargetProgressResult result)
+    {
+        var item = Resolve(user, target);
+        if (item is null)
+        {
+            // Keep the last known value. A collection deleted this morning
+            // should not zero everyone's progress bar this afternoon.
+            _logger.LogDebug("[AchievementBadges] Target did not resolve: {Name}", target.Name);
+            return;
+        }
+
+        var key = item.Id.ToString("N");
+
+        if (target.Metric == AchievementMetric.ItemPlayCount)
+        {
+            var data = _userDataManager.GetUserData(user, item);
+            result.PlayCounts[key] = data?.PlayCount ?? 0;
+            return;
+        }
+
+        if (item is not Folder folder)
+        {
+            return;
+        }
+
+        var leaves = Leaves(user, folder);
+        var played = leaves.Count(l => _userDataManager.GetUserData(user, l)?.Played == true);
+        var percent = Percent(leaves.Count, played);
+        if (percent.HasValue)
+        {
+            result.ContainerPercents[key] = percent.Value;
+        }
+    }
+
+    private BaseItem? Resolve(User user, ObservedTarget target)
+    {
+        if (target.Id != Guid.Empty)
+        {
+            var byId = _libraryManager.GetItemById(target.Id);
+            if (byId is not null)
+            {
+                return byId;
+            }
+        }
+
+        // Fallback by name. This is the case a mass rename upstream of
+        // Jellyfin produces: the item was deleted and re-added, so the GUID is
+        // dead while the title is intact.
+        var query = new InternalItemsQuery(user)
+        {
+            Name = target.Name,
+            Recursive = true,
+            EnableTotalRecordCount = false,
+        };
+
+        var matches = _libraryManager.GetItemsResult(query).Items;
+        if (matches.Count != 1)
+        {
+            // Zero means gone; more than one means ambiguous, and guessing
+            // would silently attach the badge to the wrong show.
+            return null;
+        }
+
+        var found = matches[0];
+        RewriteParameter(target, found.Id);
+        return found;
+    }
+
+    private void RewriteParameter(ObservedTarget target, Guid resolvedId)
+    {
+        foreach (var badge in _customBadges.GetEnabled())
+        {
+            if (RewriteNode(badge.Criteria, target, resolvedId))
+            {
+                _customBadges.Upsert(badge);
+                _logger.LogInformation(
+                    "[AchievementBadges] Target {Name} re-resolved to {Id}; badge {Badge} updated",
+                    target.Name, resolvedId, badge.Name);
+            }
+        }
+    }
+
+    private static bool RewriteNode(CustomBadgeCriteria? node, ObservedTarget target, Guid resolvedId)
+    {
+        if (node is null)
+        {
+            return false;
+        }
+
+        if (node.Children is { Count: > 0 })
+        {
+            var changed = false;
+            foreach (var child in node.Children)
+            {
+                changed |= RewriteNode(child, target, resolvedId);
+            }
+
+            return changed;
+        }
+
+        if (node.Metric != target.Metric
+            || !string.Equals(node.MetricParameter, target.Parameter, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        node.MetricParameter = TargetRef.Format(resolvedId, target.Name);
+        return true;
+    }
+
+    private IReadOnlyList<BaseItem> Leaves(User user, Folder folder)
+    {
+        if (!IsLinkedContainer(folder))
+        {
+            return Descendants(user, folder.Id);
+        }
+
+        var leaves = new List<BaseItem>();
+        foreach (var child in folder.GetLinkedChildren(user))
+        {
+            if (child is Folder inner)
+            {
+                leaves.AddRange(Descendants(user, inner.Id));
+            }
+            else
+            {
+                leaves.Add(child);
+            }
+        }
+
+        return leaves;
+    }
+
+    /// <summary>
+    /// Collections and playlists hold members as linked children, which an
+    /// AncestorIds query does not reach. Matched on type name rather than on
+    /// the concrete types so this file does not take a compile-time reference
+    /// to the collections and playlists assemblies for a two-branch decision.
+    /// </summary>
+    private static bool IsLinkedContainer(Folder folder)
+    {
+        var typeName = folder.GetType().Name;
+        return string.Equals(typeName, "BoxSet", StringComparison.Ordinal)
+            || string.Equals(typeName, "Playlist", StringComparison.Ordinal);
+    }
+
+    private IReadOnlyList<BaseItem> Descendants(User user, Guid ancestorId)
+    {
+        var query = new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = LeafKinds,
+            AncestorIds = new[] { ancestorId },
+            Recursive = true,
+            EnableTotalRecordCount = false,
+        };
+
+        return _libraryManager.GetItemsResult(query).Items;
+    }
+
+    private bool Contains(User user, ObservedTarget target, BaseItem item)
+    {
+        if (target.Id == Guid.Empty)
+        {
+            // Unresolved targets are always recomputed: that pass is what
+            // resolves them.
+            return true;
+        }
+
+        if (target.Metric == AchievementMetric.ItemPlayCount)
+        {
+            return target.Id == item.Id;
+        }
+
+        if (_libraryManager.GetItemById(target.Id) is not Folder folder)
+        {
+            return true;
+        }
+
+        if (IsLinkedContainer(folder))
+        {
+            return Leaves(user, folder).Any(l => l.Id == item.Id);
+        }
+
+        var query = new InternalItemsQuery(user)
+        {
+            AncestorIds = new[] { target.Id },
+            ItemIds = new[] { item.Id },
+            Recursive = true,
+            EnableTotalRecordCount = false,
+        };
+
+        return _libraryManager.GetItemsResult(query).Items.Count > 0;
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/WatchHistoryBackfillService.cs
@@ -31,6 +31,7 @@ public class WatchHistoryBackfillService
     private readonly IUserDataManager _userDataManager;
     private readonly AchievementBadgeService _achievementBadgeService;
     private readonly LibraryCompletionService _libraryCompletionService;
+    private readonly TargetProgressService _targetProgress;
     private readonly TracearrCreditLedger _tracearrLedger;
 
     /// <summary>
@@ -48,6 +49,7 @@ public class WatchHistoryBackfillService
         IUserDataManager userDataManager,
         AchievementBadgeService achievementBadgeService,
         LibraryCompletionService libraryCompletionService,
+        TargetProgressService targetProgress,
         TracearrCreditLedger tracearrLedger,
         WatchCarryStore carried,
         ILogger<WatchHistoryBackfillService> logger)
@@ -57,6 +59,7 @@ public class WatchHistoryBackfillService
         _userDataManager = userDataManager;
         _achievementBadgeService = achievementBadgeService;
         _libraryCompletionService = libraryCompletionService;
+        _targetProgress = targetProgress;
         _tracearrLedger = tracearrLedger;
         _carried = carried;
         _logger = logger;
@@ -710,6 +713,11 @@ public class WatchHistoryBackfillService
                 // discography metric without a caller would leave it in the
                 // exact dead state this issue was opened about.
                 _libraryCompletionService.RecomputeArtistsForUser(userGuid);
+                // [issue #107] The scan is the reconciler for targeted badges
+                // too. The live path only ever sees targets containing an item
+                // the user just played; a target nobody has touched since the
+                // badge was authored is computed here.
+                _targetProgress.RecomputeForUser(userGuid);
             }
             catch (Exception ex)
             {

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Big thanks to **[@camarigor](https://github.com/camarigor)** for the friend prof
 - **8 book badges (v2.1.0)** — books completed, audiobook listening hours, and series completed. Audiobook plays route per the **audiobook-counting policy** (Books-only default / Music-only / Both).
 - **Improved anime detection (v2.1.0, #25)** — matches **Genres *and* Tags** on the item *and its parent Series*, with admin-configurable libraries / genres / tags.
 - **Admin-authored custom badges (v2.1.0)** — compound AND/OR criteria across any metric; see [Custom badges](#-custom-badges).
+- **Targeted badges (v2.4.0, #107)** — point a badge at one specific series, season, collection, playlist, album or item; see [Targeted badges](#targeted-badges).
 - **6 rarity tiers** — Common, Uncommon, Rare, Epic, Legendary, Mythic
 - **Hidden/secret badges** displayed as `???` until unlocked
 - **Library completion milestones** that auto-scale to any library structure
@@ -405,6 +406,38 @@ A badge's `criteria` is a tree. A node is **either**:
 - a **compound**: `{ "operator": "And" | "Or", "children": [ <node>, ... ] }` — true when And(all)/Or(any) of children are true.
 
 Limits: max depth **5**, max **64** nodes per badge, max **500** badges per instance.
+
+### Targeted badges
+
+> Added in **v2.4.0**, from [#107](https://github.com/ZL154/AchievementBadges_for_Jellyfin/issues/107).
+
+Two metrics point at one specific thing in your library rather than at an aggregate:
+
+- `ContainerCompletionPercent` — played items over total items of one **series, season, collection, playlist or album**. Threshold 100 means "you finished it".
+- `ItemPlayCount` — how many times **one specific item** has been played. Threshold 1 is "you watched this movie"; larger thresholds are for the track you keep going back to.
+
+Both take their target in `metricParameter`, formatted `"{guid}|{name}"`. The config page has a library picker that writes it for you. Both halves are stored on purpose: the GUID survives a rename, and the name survives an item being deleted and re-added, so the badge re-resolves itself and rewrites the GUID.
+
+For an **arbitrary group of episodes**, such as one story arc of a long-running show, make a Jellyfin collection and point a `ContainerCompletionPercent` badge at it. That keeps the grouping in a native Jellyfin feature instead of a badge-editor episode list.
+
+Targeted badges are evaluated against your existing history, so a badge you author today unlocks immediately for anyone who already finished the target, with no scan needed. The number of distinct targets across all badges is capped by `MaxTargetedBadgeTargets` (default 50); anything past the cap is named in the log rather than dropped silently.
+
+#### Template — finish one series
+
+```jsonc
+// POST /Plugins/AchievementBadges/custom-badges
+{
+  "name": "Straw Hat",
+  "description": "Finish One Piece: Alabasta.",
+  "rarity": "Epic",
+  "media": "TV",
+  "criteria": {
+    "metric": "ContainerCompletionPercent",
+    "metricParameter": "8f4e2a1b9c3d4e5f6a7b8c9d0e1f2a3b|One Piece: Alabasta",
+    "threshold": 100
+  }
+}
+```
 
 ### Template — simple badge
 

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -25,6 +25,13 @@ Requested by **@unknownTGG** in #107.
 
 ## Verification
 
-- Full automated suite passes on .NET 9 / Jellyfin 10.11.x with zero build warnings, including new coverage for the target parser, the target collector, the empty-container guard and the merge-not-replace contract on both new counter maps.
+- 234/234 automated tests pass on .NET 9 / Jellyfin 10.11.x with zero build warnings, including new coverage for the target parser, the target collector, the empty-container guard and the merge-not-replace contract on both new counter maps.
 - The admin page JavaScript passes syntax validation.
-- Deployed and smoke-tested on a healthy Jellyfin 10.11.x instance.
+- Deployed and exercised against a live Jellyfin 10.11.11 with a 28-profile install:
+  - A completion badge on a fully watched 73-episode series unlocked 0.5 seconds after being authored, with no scan.
+  - A completion badge on a partly watched series read 83, matching Jellyfin's own 38 of 46.
+  - Marking one more episode played by hand, with no playback at all, moved it 83 to 85; unmarking moved it back, and the other target's stored 100 was untouched, which is the merge-not-replace contract holding on live data.
+  - A play-count badge on a film with 30 plays unlocked immediately against history that predates the feature.
+  - A collection badge went 0 to 25 when one of its four films was marked played, confirming that linked children are read; an AncestorIds query alone returns nothing for a BoxSet.
+  - A badge authored with a dead GUID and a live name re-resolved by name and rewrote its own parameter with the correct GUID.
+  - Seeding a newly authored badge across 28 profiles took one second.

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -1,0 +1,30 @@
+# v2.4.0 - Badges that point at one thing
+
+Until now every achievement counted an aggregate: items watched, percentage of a library, tracks of a genre. None of them could point at a specific show, season or track. This release adds two metrics that can. **Drop-in upgrade from v2.3.x - no schema breakage or manual migration.**
+
+## Added - targeted badges
+
+Requested by **@unknownTGG** in #107.
+
+- **Completion of one container.** `ContainerCompletionPercent` counts played items over total items of one series, season, collection, playlist or album. Threshold 100 means you finished it.
+- **Plays of one item.** `ItemPlayCount` reads Jellyfin's own play count for a single item. Threshold 1 covers "watched this movie"; larger thresholds cover the track you keep going back to.
+- **Library picker in the admin page.** Both metrics take their target from a search field rather than from a hand-typed ID. The stored parameter keeps the GUID and the name together, so a badge survives both a rename and an item being deleted and re-added: when the GUID goes stale the name resolves it and the parameter is rewritten with the new GUID.
+- **Arbitrary groupings through collections.** For something the library has no container for, such as one story arc of a long-running show, make a Jellyfin collection and point a completion badge at it. That keeps the grouping in a native Jellyfin feature instead of a badge-editor episode list.
+- **Retroactive on creation.** Authoring a targeted badge recomputes it for every profile immediately, so anyone who already finished the target unlocks it without waiting for a watch-history scan.
+- **Moves on manual marking, not only on playback.** The trigger is Jellyfin's own played flag, so marking a season watched by hand advances the badge. That is how an old arc actually gets completed.
+- **Bounded cost.** Only the targets that enabled badges actually reference are ever computed. `MaxTargetedBadgeTargets` (default 50) caps how many, and targets past the cap are named in the log rather than dropped silently.
+
+## Changed
+
+- The `library-completion/recompute` endpoint now also recomputes targeted progress and returns it, so a broken or unwanted scan does not leave targeted badges unreachable.
+- A custom badge whose criteria use a targeted metric without a target is now rejected at write time. It could never unlock, and it failed silently: the badge rendered and sat at zero with nothing in the log.
+
+## Fixed
+
+- The artist-completion ordinal test asserted that `ArtistCompletionPercent` was the last value in the metric enum. That is a proxy for the invariant it protects rather than the invariant itself, and it failed on the first correct append after it. It now pins the ordinal (70), which is the value that must never move.
+
+## Verification
+
+- Full automated suite passes on .NET 9 / Jellyfin 10.11.x with zero build warnings, including new coverage for the target parser, the target collector, the empty-container guard and the merge-not-replace contract on both new counter maps.
+- The admin page JavaScript passes syntax validation.
+- Deployed and smoke-tested on a healthy Jellyfin 10.11.x instance.


### PR DESCRIPTION
Closes #107.

Every metric in the plugin today is aggregate: it counts items or computes a percentage over a set. None of them can point at one specific thing in the library. That is what #107 asked for: badges for finishing a particular show or season, for a particular movie or episode, for playing one track a given number of times, and for finishing "each arc on One Piece".

This adds two metrics that cover all of it.

## What is new

- **`ContainerCompletionPercent`** - played leaves over total leaves of one series, season, collection, playlist or album. Threshold 100 means the user finished it.
- **`ItemPlayCount`** - Jellyfin's own play count for one item. Threshold 1 is "watched this movie"; larger thresholds are the "3005 times" case from the issue.
- **A library picker in the config page**, so nobody types an item ID by hand.

Arbitrary groupings, like one story arc of a long-running show, are expressed as a native Jellyfin collection that a completion badge points at. That seemed better than shipping an episode-list editor inside the badge builder: collections already exist, users already know them, and they cover cases we would never anticipate.

## Design notes worth reviewing

**Why the values are persisted rather than resolved on demand.** `GetMetricValue` is static and pure, and `EvaluateBadges` runs entirely inside `lock (_lock)`. Resolving targets live would put library queries under a plugin-global lock on a path that runs on every play, for every user. Instead the two new counter maps follow the shape `LibraryCompletionPercents` and `ArtistCompletionPercents` already use.

**Why the trigger is `UserDataSaved` and not our own credit decision.** The metrics are defined over Jellyfin's played flag and play count, so they have to move exactly when those move. Marking a season watched by hand is how someone completes an arc they watched years ago elsewhere, and no playback event fires for that.

**Merge, never replace.** The scoped recompute touches only the targets containing the item that changed. Replacing there would wipe every other target's progress on each play, which is the defect fixed for artists in 3c23df4.

**Two container shapes.** Series, Season and MusicAlbum are real folders and resolve through `AncestorIds`. BoxSet and Playlist derive from `Folder` too, but hold their members as linked children, which `AncestorIds` does not reach, so those go through `GetLinkedChildren`.

**Target identity is `guid|name`.** A GUID does not survive an item being deleted and re-added, which is routine after a mass rename upstream of Jellyfin; a name does not survive a rename. Storing both lets each cover the other, and when the name resolves a dead GUID the parameter is rewritten in place.

**Bounded cost.** Only targets referenced by enabled badges are ever computed, capped by `MaxTargetedBadgeTargets` (default 50). Targets past the cap are named in a warning rather than dropped silently.

## Verification

234/234 tests pass on .NET 9 with zero build warnings. New coverage: the `guid|name` parser including a display name containing the separator, the criteria walk with dedup and cap, the empty-container guard, and the merge-not-replace contract on both maps.

Deployed to a live Jellyfin 10.11.11 with 28 profiles:

| Case | Result |
| --- | --- |
| Completion badge on a fully watched 73-episode series | unlocked 0.5s after being authored, no scan |
| Completion badge on a partly watched series | read 83, matching Jellyfin's own 38 of 46 |
| One more episode marked played by hand, no playback | 83 to 85; unmarking returned it to 83 |
| Other target during that recompute | stayed at its stored 100 (merge contract) |
| Play-count badge on a film with 30 prior plays | unlocked immediately against pre-existing history |
| Collection badge, one of four films marked played | 0 to 25, confirming linked children are read |
| Badge authored with a dead GUID and a live name | re-resolved by name and rewrote its own parameter |
| Seeding a new badge across 28 profiles | 1 second |

The collection case is the one worth calling out: it first returned 0, which was also the correct answer, since none of its films were watched. Zero is indistinguishable between "read correctly, nothing watched" and "could not read the container at all", so it was re-run with one film marked played to force the two apart.

## Notes

- Both metrics are appended at the end of `AchievementMetric`, so no serialized ordinal moves.
- `ArtistCompletionTests` asserted that `ArtistCompletionPercent` was the last enum value. That is a proxy for the invariant it protects and fails on any correct append after it, so it now pins the ordinal (70) instead.
- A targeted metric authored with no target is rejected at write time. It could never unlock and it failed silently.
- No localization changes: the config page is not wired to `Pages/translations/`, and custom badge names come from the admin.
