### PR TITLE
Toast placement never applied under the Revamp style, all five positions rendered top-right (#116)

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/PlayerOverlayTests.cs
@@ -69,13 +69,30 @@ public class PlayerOverlayTests
     public void ToastContainer_InlineFallback_MatchesTheStylesheet()
     {
         // enhance.js builds the container before any sheet is guaranteed to be
-        // loaded, so the inline style has to agree or the first toast of a
+        // loaded, so the inline default has to agree or the first toast of a
         // session lands on the subtitles anyway.
         var js = ReadEmbedded("enhance.js");
 
-        Assert.Contains("top:4.5em;right:1.2em", js);
-        Assert.Contains("align-items:flex-end", js);
+        Assert.Contains("top: '4.5em', right: '1.2em'", js);
+        Assert.Contains("'align-items': 'flex-end'", js);
         Assert.DoesNotContain("bottom:24px;left:0;right:0", js);
+    }
+
+    [Fact]
+    public void ToastContainer_InlinePlacementOutranksTheStylesheet()
+    {
+        // Issue #116. The stylesheet pins the container top-right with
+        // !important, and a plain inline declaration loses to that, so the
+        // per-user placement never moved the container: every option rendered
+        // top-right with the Revamp style. The placement has to be written with
+        // the "important" priority, the one thing that outranks a stylesheet
+        // !important. The z-index stays a plain declaration on purpose, so the
+        // stylesheet keeps the container above page chrome.
+        var js = ReadEmbedded("enhance.js");
+
+        Assert.Contains("c.style.setProperty(name, props[name], 'important')", js);
+        Assert.Contains("z-index:99999;", js);
+        Assert.DoesNotContain("'z-index': ", js);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
@@ -156,25 +156,42 @@
     }
 
     // Per-user toast placement (#74 moved the default off the subtitle line to
-    // top-right). "bottom-center" restores the original spot. Kept as inline
-    // cssText so it fully overrides the #ab-toast-container rule in
-    // styles-revamp.css and cleanly clears the opposite edges when it changes.
+    // top-right). "bottom-center" restores the original spot.
+    //
+    // [issue #116] The six placement properties are written with the
+    // "important" priority. styles-revamp.css pins #ab-toast-container to
+    // top-right with !important on top, right, bottom, left, align-items and
+    // transform (#74 wanted it off the subtitle line no matter what), and an
+    // ordinary inline declaration loses to a stylesheet !important. So the
+    // preference never moved the container: every placement rendered top-right
+    // whenever the Revamp style was active, from the day the setting shipped.
+    // Inline !important is the one thing that outranks a stylesheet !important.
+    // Every edge is set, the unused ones as "auto", so switching placement
+    // clears the previous edges instead of stretching the box between them.
+    // z-index deliberately stays a plain declaration: the stylesheet raises it
+    // far above 99999 on purpose, and that must keep winning.
     var _toastPos = 'top-right';
     function normalizeToastPos(v) {
         v = (v || '').toString().toLowerCase();
         return (v === 'top-left' || v === 'bottom-right' || v === 'bottom-left' || v === 'bottom-center') ? v : 'top-right';
     }
-    function toastPosCss(pos) {
+    function toastPosProps(pos) {
         switch (pos) {
-            case 'top-left':      return 'top:4.5em;left:1.2em;align-items:flex-start;';
-            case 'bottom-right':  return 'bottom:1.2em;right:1.2em;align-items:flex-end;';
-            case 'bottom-left':   return 'bottom:1.2em;left:1.2em;align-items:flex-start;';
-            case 'bottom-center': return 'bottom:1.2em;left:50%;transform:translateX(-50%);align-items:center;';
-            default:              return 'top:4.5em;right:1.2em;align-items:flex-end;';
+            case 'top-left':      return { top: '4.5em', right: 'auto',  bottom: 'auto',  left: '1.2em', transform: 'none',             'align-items': 'flex-start' };
+            case 'bottom-right':  return { top: 'auto',  right: '1.2em', bottom: '1.2em', left: 'auto',  transform: 'none',             'align-items': 'flex-end' };
+            case 'bottom-left':   return { top: 'auto',  right: 'auto',  bottom: '1.2em', left: '1.2em', transform: 'none',             'align-items': 'flex-start' };
+            case 'bottom-center': return { top: 'auto',  right: 'auto',  bottom: '1.2em', left: '50%',   transform: 'translateX(-50%)', 'align-items': 'center' };
+            default:              return { top: '4.5em', right: '1.2em', bottom: 'auto',  left: 'auto',  transform: 'none',             'align-items': 'flex-end' };
         }
     }
     function positionToastContainer(c) {
-        c.style.cssText = 'position:fixed;z-index:99999;display:flex;flex-direction:column;gap:14px;pointer-events:none;' + toastPosCss(_toastPos);
+        c.style.cssText = 'position:fixed;z-index:99999;display:flex;flex-direction:column;gap:14px;pointer-events:none;';
+        var props = toastPosProps(_toastPos);
+        for (var name in props) {
+            if (Object.prototype.hasOwnProperty.call(props, name)) {
+                try { c.style.setProperty(name, props[name], 'important'); } catch (e) { }
+            }
+        }
     }
     function ensureToastContainer() {
         var c = document.getElementById(TOAST_ID);

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -21,6 +21,7 @@ Requested by **@unknownTGG** in #107.
 
 ## Fixed
 
+- **Toast position never applied (#116).** `styles-revamp.css` pins the toast container to top-right with `!important`, and the per-user placement from v2.3.0 wrote a plain inline style, which loses to a stylesheet `!important`. So with the Revamp style active every placement rendered top-right, not only bottom-center as reported. The placement is now written with inline `!important`, which is the one thing that outranks the stylesheet; the stylesheet's z-index is left in charge on purpose. Reproduced and verified in a browser against a verbatim copy of the rule: before the fix all five placements landed top-right, after it each lands where it says.
 - The artist-completion ordinal test asserted that `ArtistCompletionPercent` was the last value in the metric enum. That is a proxy for the invariant it protects rather than the invariant itself, and it failed on the first correct append after it. It now pins the ordinal (70), which is the value that must never move.
 
 ## Verification


### PR DESCRIPTION
Closes #116.

@TsunamicFlame reported that selecting "bottom-center" for the toast position still shows toasts top-right. I can confirm it, and the actual scope is wider than the report: **none of the five placements ever applied** while the Revamp style is active. It has been that way since the setting shipped in v2.3.0.

## Root cause

Two commits that are each correct on their own, two days apart:

- `7f7781d` (#74) pinned `#ab-toast-container` to top-right in `styles-revamp.css` with `!important` on `top`, `right`, `bottom`, `left`, `align-items` and `transform`, so the toast stays off the subtitle line no matter what.
- `acb44d0` (v2.3.0) added the per-user placement in `enhance.js` by writing a plain inline `cssText`.

An ordinary inline declaration loses to a stylesheet `!important`. The comment in `enhance.js` said the inline style "fully overrides" the stylesheet rule; it never did. The only thing that outranks a stylesheet `!important` is an inline `!important`.

This only bites with the Revamp style, because `styles-revamp.css` is injected into the main Jellyfin web only in that style (`sidebar.js`). Classic never loads the rule, so the inline style works there.

## Fix

`enhance.js` only. `positionToastContainer` now writes the six placement properties (`top`, `right`, `bottom`, `left`, `transform`, `align-items`) through `style.setProperty(name, value, 'important')`, setting every edge explicitly (unused ones as `auto`) so a change of placement clears the previous edges instead of stretching the box between two of them.

`z-index` is deliberately left as a plain declaration: the stylesheet raises it to 2147483000 on purpose ("well above any conceivable page chrome"), and that must keep winning. I checked that it does.

I chose to fix the JS rather than relax the CSS for a delivery reason as much as a correctness one: `enhance.js` is served under the build-specific cache tag, so the fix reaches browsers on the next page load. `styles-revamp.css` is loaded with a hard-coded `v=1.9.2` bust key under `max-age=86400, immutable`, so a CSS-only fix would take up to a day to arrive. That stale key is a separate issue and I have not touched it here.

## Verification

I reproduced the bug in a browser page containing a verbatim copy of the `#ab-toast-container` rule from `styles-revamp.css` and both versions of the positioning function, then classified where the toast actually landed for each placement:

| Placement | Before (plain inline) | After (inline `!important`) |
| --- | --- | --- |
| top-right | top-right | top-right |
| top-left | **top-right** | top-left |
| bottom-right | **top-right** | bottom-right |
| bottom-left | **top-right** | bottom-left |
| bottom-center | **top-right** | bottom-center |

Computed `z-index` after the fix: `2147483000` (the stylesheet's value), so the fix does not lower the container below page chrome.

`node --check` passes on the patched file. The repo has no JavaScript test harness, so the browser reproduction above is the behavioural evidence. What the suite can do is pin the source, the way `PlayerOverlayTests` already pins the stylesheet and the inline default: I updated `ToastContainer_InlineFallback_MatchesTheStylesheet` for the new shape of the default (same invariant, the inline default agrees with the stylesheet) and added `ToastContainer_InlinePlacementOutranksTheStylesheet`, which requires the placement to be written with the `important` priority and the z-index to stay a plain declaration. That second test fails against the previous `enhance.js` and passes against this one. 235/235 tests pass.

The unreleased v2.4.0 note records the fix.
