### PR TITLE
Show the equipped shop title and badge frame on the shareable card and the friends drawer (#42)

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/PublicCosmeticsTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/PublicCosmeticsTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #42, follow-up: the shop sells a custom title and a badge frame that
+/// only the owner could see, because neither the shareable card nor the
+/// friends-drawer summary read them. These pin the projection that fixes it,
+/// and the two properties that keep it safe: it resolves against the catalog
+/// (a stale id becomes nothing, not markup) and it obeys the same privacy
+/// toggles as the equipped badge preview.
+/// </summary>
+public class PublicCosmeticsTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly Mock<IApplicationPaths> _paths;
+    private readonly AchievementBadgeService _badges;
+
+    private const string Target = "88888888-8888-8888-8888-888888888888";
+
+    public PublicCosmeticsTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "abcosm_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        _paths = new Mock<IApplicationPaths>();
+        _paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        _badges = Build(withShop: true);
+    }
+
+    private AchievementBadgeService Build(bool withShop)
+    {
+        var shop = withShop
+            ? new ShopService(new PowerUpService(NullLogger<PowerUpService>.Instance), NullLogger<ShopService>.Instance)
+            : null;
+
+        return new AchievementBadgeService(
+            _paths.Object,
+            new Mock<IUserManager>().Object,
+            new WebhookNotifier(NullLogger<WebhookNotifier>.Instance),
+            new AuditLogService(_paths.Object, NullLogger<AuditLogService>.Instance),
+            NullLogger<AchievementBadgeService>.Instance,
+            shop: shop);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private static void Seed(AchievementBadgeService badges, string? titleId, string? frameId)
+    {
+        badges.RecordPlayback(new PlaybackContext
+        {
+            UserId = Target,
+            ItemId = Guid.NewGuid().ToString("D"),
+            IsMovie = true,
+            Silent = true
+        });
+
+        var profile = badges.GetOrCreateProfileDirect(Target);
+        profile.EquippedCustomTitleId = titleId;
+        profile.EquippedBadgeFrameId = frameId;
+        badges.SaveProfileDirect(profile);
+    }
+
+    [Fact]
+    public void EquippedTitleAndFrame_ReachTheCardAndTheSummary()
+    {
+        // The reporter's exact case: bought "Tastemaker" and "Gilded", nobody
+        // else could see either.
+        Seed(_badges, "title-tastemaker", "frame-gilded");
+
+        var card = _badges.GetPublicCosmetics(Target);
+        Assert.Equal("Tastemaker", card.CustomTitle);
+        Assert.Equal("frame-gilded", card.BadgeFrameId);
+
+        var summary = _badges.GetPublicProfileSummary(Target);
+        Assert.NotNull(summary);
+        Assert.Equal("Tastemaker", summary!.GetType().GetProperty("CustomTitle")!.GetValue(summary));
+        Assert.Equal("frame-gilded", summary.GetType().GetProperty("BadgeFrameId")!.GetValue(summary));
+    }
+
+    [Fact]
+    public void AHiddenShowcase_HidesTheBlingToo()
+    {
+        // The card must never show more than the equipped preview does. A user
+        // who turned the showcase off gets a plain card, title and frame
+        // included.
+        Seed(_badges, "title-tastemaker", "frame-gilded");
+        var profile = _badges.GetOrCreateProfileDirect(Target);
+        profile.Preferences.ShowEquippedShowcase = false;
+        _badges.SaveProfileDirect(profile);
+
+        var card = _badges.GetPublicCosmetics(Target);
+        Assert.Null(card.CustomTitle);
+        Assert.Null(card.BadgeFrameId);
+    }
+
+    [Fact]
+    public void TheDefaultFrameAndAnUnknownTitle_ReadAsNothing()
+    {
+        // frame-default is what everyone has, so it is not bling. An id the
+        // catalog does not know (renamed, removed, hand-edited) must become
+        // nothing rather than a CSS class or a title in the markup.
+        Seed(_badges, "title-does-not-exist", "frame-default");
+
+        var card = _badges.GetPublicCosmetics(Target);
+        Assert.Null(card.CustomTitle);
+        Assert.Null(card.BadgeFrameId);
+    }
+
+    [Fact]
+    public void AFrameIdOfAnotherKind_IsNotAcceptedAsAFrame()
+    {
+        // The frame id becomes a CSS class on the card, so it can only ever
+        // be an id the catalog lists as a frame, not any catalog id.
+        Seed(_badges, null, "title-tastemaker");
+
+        Assert.Null(_badges.GetPublicCosmetics(Target).BadgeFrameId);
+    }
+
+    [Fact]
+    public void WithoutAShop_NothingShowsAndNothingThrows()
+    {
+        // ShopService is an optional dependency of the badge service.
+        var badges = Build(withShop: false);
+        Seed(badges, "title-tastemaker", "frame-gilded");
+
+        var card = badges.GetPublicCosmetics(Target);
+        Assert.Null(card.CustomTitle);
+        Assert.Null(card.BadgeFrameId);
+    }
+
+    [Fact]
+    public void AnUnknownUser_ReadsAsNothing()
+    {
+        // Same shape as the public summary: no way to tell an unknown id from
+        // a hidden one.
+        var card = _badges.GetPublicCosmetics("99999999-9999-9999-9999-999999999999");
+        Assert.Null(card.CustomTitle);
+        Assert.Null(card.BadgeFrameId);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/PublicProfileSummaryTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/PublicProfileSummaryTests.cs
@@ -88,7 +88,10 @@ public class PublicProfileSummaryTests : IDisposable
         var expected = new[]
         {
             "UserId", "UserName", "Unlocked", "Total", "Percentage",
-            "Score", "BestWatchStreak", "Equipped"
+            "Score", "BestWatchStreak", "Equipped",
+            // Issue #42: the equipped custom title and badge frame, published
+            // on the leaderboard first and repeated here.
+            "CustomTitle", "BadgeFrameId"
         };
         var actual = summary!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
 

--- a/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Api/AchievementBadgesController.cs
@@ -1528,6 +1528,14 @@ public class AchievementBadgesController : ControllerBase
                 equippedHtml = "<span class=\"tier\">No badges equipped.</span>";
             }
 
+            // [issue #42] Shop bling the owner equipped: custom title and badge
+            // frame. Resolved against the catalog and privacy gated by the
+            // service, so both are either a known catalog value or empty, and
+            // the templates collapse the empty case with CSS.
+            var cosmetics = _badgeService.GetPublicCosmetics(userId);
+            var customTitle = System.Net.WebUtility.HtmlEncode(cosmetics.CustomTitle ?? string.Empty);
+            var frameClass = System.Net.WebUtility.HtmlEncode(cosmetics.BadgeFrameId ?? string.Empty);
+
             var recap = _recapService.GetRecap(userId, "month");
             var recapType = recap.GetType();
             int recapMovies = (int)(recapType.GetProperty("MoviesWatched")?.GetValue(recap) ?? 0);
@@ -1555,7 +1563,9 @@ public class AchievementBadgesController : ControllerBase
                 .Replace("{{recapMovies}}", recapMovies.ToString())
                 .Replace("{{recapEpisodes}}", recapEpisodes.ToString())
                 .Replace("{{recapUnlocks}}", recapUnlocks.ToString())
-                .Replace("{{equippedHtml}}", equippedHtml);
+                .Replace("{{equippedHtml}}", equippedHtml)
+                .Replace("{{customTitle}}", customTitle)
+                .Replace("{{frameClass}}", frameClass);
         }
         catch
         {

--- a/Jellyfin.Plugin.AchievementBadges/Models/PublicCosmetics.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/PublicCosmetics.cs
@@ -1,0 +1,29 @@
+namespace Jellyfin.Plugin.AchievementBadges.Models;
+
+/// <summary>
+/// [issue #42] The equipped shop cosmetics a user shows to other people:
+/// the custom rank title and the badge frame. Resolved against the shop
+/// catalog, so a stale or unknown id comes back as null instead of leaking
+/// into markup, and gated by the same privacy toggles as the equipped badge
+/// preview: a user who hid their showcase shows no bling either.
+/// <para>
+/// The profile theme is not here on purpose. The shareable card skins are
+/// drawn in the rank tier's colour, and painting them in the user's theme
+/// is a redesign of the three templates rather than a projection of data.
+/// </para>
+/// </summary>
+public sealed class PublicCosmetics
+{
+    /// <summary>Display name of the equipped custom title (for example
+    /// "Tastemaker"), or null when none is equipped or the id is not in the
+    /// catalog.</summary>
+    public string? CustomTitle { get; init; }
+
+    /// <summary>Catalog id of the equipped badge frame (for example
+    /// "frame-gilded"), or null for the default frame, an unknown id, or a
+    /// hidden showcase. Safe to use as a CSS class: it can only be an id
+    /// that exists in the catalog.</summary>
+    public string? BadgeFrameId { get; init; }
+
+    public static PublicCosmetics None { get; } = new();
+}

--- a/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-blades.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-blades.html
@@ -84,6 +84,19 @@
   .eq{ display:flex; flex-wrap:wrap; gap:7px; position:relative; }
   .badge-chip{ padding:6px 11px; border-radius:7px; font-size:12px; font-weight:600; color:var(--ink); background:rgba(255,255,255,.05); border:1px solid var(--line); }
   .eq .tier{ color:var(--dim); font-size:12px; background:none; border:none; padding:6px 2px; }
+  /* [issue #42] Equipped badge frame from the shop, as a class on .eq.
+     Same colours the achievements page paints on equipped badge cards. */
+  .eq.frame-gilded .badge-chip{ border-color:#facc15; box-shadow:0 0 0 1px #facc15, 0 0 12px rgba(250,204,21,.45); }
+  .eq.frame-holo .badge-chip{ border-color:#22d3ee; box-shadow:0 0 0 1px #22d3ee, 0 0 12px rgba(34,211,238,.4); background:linear-gradient(135deg,rgba(14,165,233,.28),rgba(168,85,247,.28),rgba(236,72,153,.28)); }
+  .eq.frame-frosted .badge-chip{ border-color:#bfdbfe; box-shadow:0 0 0 1px #bfdbfe, inset 0 0 0 1px rgba(255,255,255,.35); }
+  .eq.frame-obsidian .badge-chip{ border-color:#292524; box-shadow:0 0 0 1px #292524, 0 0 12px rgba(220,38,38,.35); }
+  .eq.frame-emerald .badge-chip{ border-color:#10b981; box-shadow:0 0 0 1px #10b981, 0 0 12px rgba(16,185,129,.4); }
+  .eq.frame-neon .badge-chip{ border-color:#ec4899; box-shadow:0 0 0 1px #ec4899, 0 0 14px rgba(236,72,153,.5); }
+  /* [issue #42] Equipped custom title from the shop. Empty when none is
+     equipped or the showcase is hidden; :empty then removes the line. */
+  .ctitle{ margin-top:2px; font-size:12px; font-style:italic; font-weight:700; letter-spacing:.03em; color:var(--accent); }
+  .ctitle:empty{ display:none; }
+  .ctitle::before{ content:"\2605\00a0"; font-style:normal; font-size:.85em; }
 
   .ab-back-btn{
     position:fixed; top:max(1em, env(safe-area-inset-top,0px)); left:max(1em, env(safe-area-inset-left,0px));
@@ -109,6 +122,7 @@
         <div class="av"><span class="ini">{{userInitial}}</span><span class="img"></span></div>
         <div class="id">
           <div class="nm">{{userName}}</div>
+          <div class="ctitle">{{customTitle}}</div>
           <div class="sub"><b>{{unlocked}}</b> of <b>{{total}}</b> badges</div>
         </div>
         <div class="ring"><div class="pct">{{percentage}}%</div></div>
@@ -133,7 +147,7 @@
       </div>
 
       <div class="eqh">Equipped</div>
-      <div class="eq">{{equippedHtml}}</div>
+      <div class="eq {{frameClass}}">{{equippedHtml}}</div>
     </div>
   </div>
 </body>

--- a/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-metro.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-metro.html
@@ -64,6 +64,19 @@
   .badge-chip{ display:flex; align-items:center; gap:9px; padding:9px 12px; background:var(--tile-2); border:1px solid var(--line); border-radius:2px; font-size:12.5px; font-weight:700; color:var(--ink); }
   .badge-chip::before{ content:""; width:22px; height:22px; border-radius:2px; background:linear-gradient(135deg,var(--green),var(--green-d)); flex:0 0 auto; }
   .eq .tier{ color:var(--dim); background:none; border:none; padding:0; }
+  /* [issue #42] Equipped badge frame from the shop, as a class on .eq.
+     Same colours the achievements page paints on equipped badge cards. */
+  .eq.frame-gilded .badge-chip{ border-color:#facc15; box-shadow:0 0 0 1px #facc15, 0 0 12px rgba(250,204,21,.45); }
+  .eq.frame-holo .badge-chip{ border-color:#22d3ee; box-shadow:0 0 0 1px #22d3ee, 0 0 12px rgba(34,211,238,.4); background:linear-gradient(135deg,rgba(14,165,233,.28),rgba(168,85,247,.28),rgba(236,72,153,.28)); }
+  .eq.frame-frosted .badge-chip{ border-color:#bfdbfe; box-shadow:0 0 0 1px #bfdbfe, inset 0 0 0 1px rgba(255,255,255,.35); }
+  .eq.frame-obsidian .badge-chip{ border-color:#292524; box-shadow:0 0 0 1px #292524, 0 0 12px rgba(220,38,38,.35); }
+  .eq.frame-emerald .badge-chip{ border-color:#10b981; box-shadow:0 0 0 1px #10b981, 0 0 12px rgba(16,185,129,.4); }
+  .eq.frame-neon .badge-chip{ border-color:#ec4899; box-shadow:0 0 0 1px #ec4899, 0 0 14px rgba(236,72,153,.5); }
+  /* [issue #42] Equipped custom title from the shop. Empty when none is
+     equipped or the showcase is hidden; :empty then removes the line. */
+  .ctitle{ margin-top:2px; font-size:12px; font-style:italic; font-weight:700; letter-spacing:.03em; color:var(--green-lite); }
+  .ctitle:empty{ display:none; }
+  .ctitle::before{ content:"\2605\00a0"; font-style:normal; font-size:.85em; }
   .eq .tier::before{ display:none; }
 
   .ab-back-btn{
@@ -88,6 +101,7 @@
       <div class="pic"><span class="ini">{{userInitial}}</span><span class="img"></span></div>
       <div class="hid">
         <div class="tag">{{userName}}</div>
+        <div class="ctitle">{{customTitle}}</div>
         <div class="rank">Rank&nbsp;&nbsp;{{tierName}}</div>
         <div class="gs"><span class="gi">G</span><span class="num">{{score}}</span><span class="u">Gamerscore</span></div>
       </div>
@@ -113,7 +127,7 @@
 
     <div class="tile ach">
       <div class="h">Equipped</div>
-      <div class="eq">{{equippedHtml}}</div>
+      <div class="eq {{frameClass}}">{{equippedHtml}}</div>
     </div>
   </div></div>
 </body>

--- a/Jellyfin.Plugin.AchievementBadges/Pages/profile-card.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/profile-card.html
@@ -93,6 +93,19 @@
   .eq{ display:flex; flex-wrap:wrap; gap:7px; }
   .badge-chip{ padding:6px 11px; border-radius:6px; font-size:12px; font-weight:600; color:var(--ink); background:var(--tile); border:1px solid var(--line); }
   .eq .tier{ color:var(--dim); font-size:12px; }
+  /* [issue #42] Equipped badge frame from the shop, as a class on .eq.
+     Same colours the achievements page paints on equipped badge cards. */
+  .eq.frame-gilded .badge-chip{ border-color:#facc15; box-shadow:0 0 0 1px #facc15, 0 0 12px rgba(250,204,21,.45); }
+  .eq.frame-holo .badge-chip{ border-color:#22d3ee; box-shadow:0 0 0 1px #22d3ee, 0 0 12px rgba(34,211,238,.4); background:linear-gradient(135deg,rgba(14,165,233,.28),rgba(168,85,247,.28),rgba(236,72,153,.28)); }
+  .eq.frame-frosted .badge-chip{ border-color:#bfdbfe; box-shadow:0 0 0 1px #bfdbfe, inset 0 0 0 1px rgba(255,255,255,.35); }
+  .eq.frame-obsidian .badge-chip{ border-color:#292524; box-shadow:0 0 0 1px #292524, 0 0 12px rgba(220,38,38,.35); }
+  .eq.frame-emerald .badge-chip{ border-color:#10b981; box-shadow:0 0 0 1px #10b981, 0 0 12px rgba(16,185,129,.4); }
+  .eq.frame-neon .badge-chip{ border-color:#ec4899; box-shadow:0 0 0 1px #ec4899, 0 0 14px rgba(236,72,153,.5); }
+  /* [issue #42] Equipped custom title from the shop. Empty when none is
+     equipped or the showcase is hidden; :empty then removes the line. */
+  .ctitle{ margin-top:2px; font-size:12px; font-style:italic; font-weight:700; letter-spacing:.03em; color:var(--accent); }
+  .ctitle:empty{ display:none; }
+  .ctitle::before{ content:"\2605\00a0"; font-style:normal; font-size:.85em; }
 
   .ab-back-btn{
     position:fixed; top:max(1em, env(safe-area-inset-top,0px)); left:max(1em, env(safe-area-inset-left,0px));
@@ -124,6 +137,7 @@
         <div class="av"><span class="ini">{{userInitial}}</span><span class="img"></span></div>
         <div class="who">
           <div class="name">{{userName}}</div>
+          <div class="ctitle">{{customTitle}}</div>
           <div class="sub"><b>{{unlocked}}</b> of <b>{{total}}</b> badges unlocked</div>
         </div>
         <div class="compl"><div class="n">{{percentage}}%</div><div class="k">Complete</div></div>
@@ -148,7 +162,7 @@
       </div>
 
       <div class="eqh">Equipped</div>
-      <div class="eq">{{equippedHtml}}</div>
+      <div class="eq {{frameClass}}">{{equippedHtml}}</div>
     </div>
   </div>
 </body>

--- a/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
@@ -462,13 +462,31 @@
     // sidebar.js so it's available on EVERY Jellyfin page, not just the
     // achievements tab. Anchored bottom-LEFT per user feedback.
     function rarityColour(r){ return rarityColors[(r||'').toLowerCase()] || rarityColors.common; }
-    function renderEquippedDots(eq, size){
+    // [issue #42] Ring colour of a badge frame from the shop, keyed by the
+    // catalog id the public summary hands back. Same colours the achievements
+    // page paints on equipped badge cards; unknown ids get no ring override.
+    function frameColour(id) {
+        switch (id) {
+            case 'frame-gilded':   return '#facc15';
+            case 'frame-holo':     return '#22d3ee';
+            case 'frame-frosted':  return '#bfdbfe';
+            case 'frame-obsidian': return '#292524';
+            case 'frame-emerald':  return '#10b981';
+            case 'frame-neon':     return '#ec4899';
+            default:               return '';
+        }
+    }
+
+    function renderEquippedDots(eq, size, frameId){
         if (!eq || !eq.length) return '';
         var px = size || 16;
+        var f = frameColour(frameId);
         return '<span style="display:inline-flex;gap:3px;vertical-align:middle;">' +
             eq.slice(0,5).map(function(b){
                 var c = rarityColour(b.Rarity);
-                return '<span title="'+escapeHtml(b.Title||'')+'" style="width:'+px+'px;height:'+px+'px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;background:'+c+'26;border:1.5px solid '+c+';box-shadow:0 0 6px '+c+'55;">' +
+                // Rarity keeps the fill; the equipped frame, when any, takes the ring.
+                var ring = f || c;
+                return '<span title="'+escapeHtml(b.Title||'')+'" style="width:'+px+'px;height:'+px+'px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;background:'+c+'26;border:1.5px solid '+ring+';box-shadow:0 0 6px '+ring+'55;">' +
                     '<span class="material-icons" style="font-family:Material Icons;font-size:'+Math.max(10,px-6)+'px;line-height:1;color:#fff;">'+icName(b.Icon)+'</span>' +
                 '</span>';
             }).join('') +
@@ -1317,6 +1335,7 @@
             '.ab-pc2 .ava .pct{position:absolute;left:50%;bottom:-4px;transform:translateX(-50%);background:var(--acc);color:#06222a;font:800 9.5px/1 system-ui;padding:2.5px 6px;border-radius:99px;font-variant-numeric:tabular-nums;box-shadow:0 2px 6px rgba(0,0,0,.4);white-space:nowrap;}',
             '.ab-pc2 .id{min-width:0;flex:1;}',
             '.ab-pc2 .nm{font-weight:650;font-size:17px;letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}',
+            '.ab-pc2 .ctitle{margin-top:2px;font-size:12px;font-style:italic;font-weight:700;letter-spacing:.03em;color:var(--acc);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}',
             '.ab-pc2 .tier{display:inline-flex;align-items:center;gap:5px;margin-top:6px;padding:3px 9px 3px 6px;border-radius:99px;background:color-mix(in srgb,var(--acc) 16%,transparent);border:1px solid color-mix(in srgb,var(--acc) 42%,transparent);color:var(--acc);font-size:10.5px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;}',
             '.ab-pc2 .tier .tdot{width:6px;height:6px;border-radius:50%;background:var(--acc);flex:0 0 auto;}',
             '.ab-pc2 .priv{display:flex;align-items:center;gap:9px;margin-top:15px;padding-top:14px;border-top:1px solid rgba(255,255,255,.07);color:rgba(255,255,255,.6);font-size:12.5px;}',
@@ -1366,11 +1385,13 @@
             : '';
         card.innerHTML =
             '<div style="font-weight:600;font-size:1.05em;margin-bottom:0.5em;">' + escapeHtml(data.UserName || '') + '</div>' +
+            // [issue #42] Equipped custom title from the shop, star prefixed.
+            (data.CustomTitle ? '<div style="margin:-0.35em 0 0.5em;font-size:0.9em;font-style:italic;font-weight:700;color:#fcd34d;">&#9733; ' + escapeHtml(data.CustomTitle) + '</div>' : '') +
             row(tr('lb.badges', 'Badges'), num(data.Unlocked) + ' / ' + num(data.Total)) +
             row(tr('profile.completion', 'Completion'), num(data.Percentage) + '%') +
             row(tr('lb.score', 'Score'), String(num(data.Score))) +
             row(tr('lb.streak', 'Best streak'), String(num(data.BestWatchStreak))) +
-            (data.Equipped && data.Equipped.length ? '<div style="margin-top:0.6em;">' + renderEquippedDots(data.Equipped, 20) + '</div>' : '') +
+            (data.Equipped && data.Equipped.length ? '<div style="margin-top:0.6em;">' + renderEquippedDots(data.Equipped, 20, data.BadgeFrameId) + '</div>' : '') +
             actions;
         card.addEventListener('click', function (ev) { if (ev.target && ev.target.closest && ev.target.closest('[data-ab-pc-close]')) hideProfileCard(); });
         card.addEventListener('mouseenter', _pcCancelHide);
@@ -1413,7 +1434,9 @@
             ? '<div class="eq"><div class="h">' + escapeHtml(tr('profile.equipped', 'Equipped')) + '</div><div class="row">' +
               data.Equipped.slice(0, 5).map(function (b) {
                   var c = rarityColour(b.Rarity);
-                  return '<span class="bdg" title="' + escapeHtml(b.Title || '') + '" style="background:' + c + '26;box-shadow:inset 0 0 0 1.5px ' + c + ';"><span class="material-icons" style="font-family:Material Icons;">' + escapeHtml(icName(b.Icon)) + '</span></span>';
+                  // [issue #42] Rarity keeps the fill; the equipped frame takes the ring.
+                  var ring = frameColour(data.BadgeFrameId) || c;
+                  return '<span class="bdg" title="' + escapeHtml(b.Title || '') + '" style="background:' + c + '26;box-shadow:inset 0 0 0 1.5px ' + ring + (ring !== c ? ', 0 0 8px ' + ring + '66' : '') + ';"><span class="material-icons" style="font-family:Material Icons;">' + escapeHtml(icName(b.Icon)) + '</span></span>';
               }).join('') + '</div></div>'
             : '';
 
@@ -1429,6 +1452,8 @@
         card.innerHTML =
             '<div class="top">' + avatar +
             '<div class="id"><div class="nm">' + escapeHtml(nm) + '</div>' +
+            // [issue #42] Equipped custom title from the shop, star prefixed.
+            (data.CustomTitle ? '<div class="ctitle">&#9733; ' + escapeHtml(data.CustomTitle) + '</div>' : '') +
             '<span class="tier"><span class="tdot"></span>' + escapeHtml(t.name) + '</span></div></div>' +
             prog +
             '<div class="stats"><div class="st"><b>' + num(data.Unlocked) + '<i>/' + num(data.Total) + '</i></b><span>' + escapeHtml(tr('lb.badges', 'Badges')) + '</span></div>' +

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -2540,6 +2540,9 @@ public class AchievementBadgeService : IDisposable
                     var total = enabled.Count;
                     var percentage = total == 0 ? 0 : Math.Round((double)unlocked / total * 100.0, 1);
                     var score = AchievementScoreHelper.GetTotalUnlockedScore(enabled);
+                    // [issue #42] Published here first, so the public summary
+                    // only ever repeats what the leaderboard already shows.
+                    var cosmetics = BuildPublicCosmetics(profile);
 
                     return new
                     {
@@ -2550,7 +2553,9 @@ public class AchievementBadgeService : IDisposable
                         Percentage = percentage,
                         Score = score,
                         BestWatchStreak = profile.Counters.BestWatchStreak,
-                        Equipped = BuildEquippedPreview(profile)
+                        Equipped = BuildEquippedPreview(profile),
+                        CustomTitle = cosmetics.CustomTitle,
+                        BadgeFrameId = cosmetics.BadgeFrameId
                     };
                 })
                 .OrderByDescending(x => x.Score)
@@ -2570,19 +2575,82 @@ public class AchievementBadgeService : IDisposable
     /// display fields — never Id, internal state, or unlock date.
     /// Returns an empty list when the target has opted out of showcases.
     /// </summary>
+    /// <summary>
+    /// The privacy gate shared by every public projection of what a user
+    /// equipped. Any one of these toggles hides the equipped badges, and
+    /// [issue #42] the custom title and badge frame with them: a user who hid
+    /// their showcase shows no bling either. Previously the equipped preview
+    /// only checked the showcase toggle, which let the pills leak for users
+    /// who had only set HideFromCompare / HideFromLeaderboard.
+    /// </summary>
+    private static bool ShowcaseHidden(UserAchievementProfile profile)
+    {
+        var prefs = profile.Preferences;
+        if (prefs?.ShowEquippedShowcase == false) return true;
+        if (prefs?.HideFromLeaderboard == true) return true;
+        if (prefs?.HideFromCompare == true) return true;
+        var cfg = Plugin.Instance?.Configuration;
+        return cfg?.ForceHideEquippedShowcase == true;
+    }
+
+    /// <summary>
+    /// [issue #42] The equipped custom title and badge frame, resolved against
+    /// the shop catalog so an unknown or stale id never reaches markup, and
+    /// hidden under the same toggles as the equipped badge preview. Without a
+    /// ShopService there is no catalog to resolve against, so nothing shows.
+    /// The default frame reads as no frame: it is what everyone has.
+    /// </summary>
+    private PublicCosmetics BuildPublicCosmetics(UserAchievementProfile profile)
+    {
+        if (_shop is null || ShowcaseHidden(profile)) return PublicCosmetics.None;
+
+        var catalog = _shop.GetCatalog().Cosmetics;
+
+        string? title = null;
+        if (!string.IsNullOrWhiteSpace(profile.EquippedCustomTitleId))
+        {
+            title = catalog.FirstOrDefault(c => c.Kind == CosmeticKind.RankTitle
+                && string.Equals(c.Id, profile.EquippedCustomTitleId, StringComparison.Ordinal))?.DisplayName;
+        }
+
+        string? frame = null;
+        if (!string.IsNullOrWhiteSpace(profile.EquippedBadgeFrameId)
+            && !string.Equals(profile.EquippedBadgeFrameId, "frame-default", StringComparison.Ordinal))
+        {
+            frame = catalog.FirstOrDefault(c => c.Kind == CosmeticKind.BadgeFrame
+                && string.Equals(c.Id, profile.EquippedBadgeFrameId, StringComparison.Ordinal))?.Id;
+        }
+
+        return new PublicCosmetics
+        {
+            CustomTitle = string.IsNullOrWhiteSpace(title) ? null : title,
+            BadgeFrameId = frame,
+        };
+    }
+
+    /// <summary>
+    /// [issue #42] What the shareable card may show of a user's shop
+    /// cosmetics. Same privacy answer as the public summary: privacy mode or
+    /// an unknown user reads as nothing, never as an error.
+    /// </summary>
+    public PublicCosmetics GetPublicCosmetics(string userId)
+    {
+        userId = NormalizeUserId(userId);
+        var config = Plugin.Instance?.Configuration;
+        if (config?.ForcePrivacyMode == true) return PublicCosmetics.None;
+
+        lock (_lock)
+        {
+            return _userProfiles.TryGetValue(userId, out var profile)
+                ? BuildPublicCosmetics(profile)
+                : PublicCosmetics.None;
+        }
+    }
+
     private List<object> BuildEquippedPreview(UserAchievementProfile profile)
     {
-        // Respect every privacy toggle — if the user opted out of either the
-        // leaderboard OR compare OR showcase, hide their equipped list from
-        // any public projection. Previously this only checked the showcase
-        // toggle which let the equipped pills leak for users who had only
-        // set HideFromCompare / HideFromLeaderboard.
+        if (ShowcaseHidden(profile)) return new List<object>();
         var prefs = profile.Preferences;
-        if (prefs?.ShowEquippedShowcase == false) return new List<object>();
-        if (prefs?.HideFromLeaderboard == true) return new List<object>();
-        if (prefs?.HideFromCompare == true) return new List<object>();
-        var cfg = Plugin.Instance?.Configuration;
-        if (cfg?.ForceHideEquippedShowcase == true) return new List<object>();
 
         var result = new List<object>();
         var lang = prefs?.Language;
@@ -2659,6 +2727,8 @@ public class AchievementBadgeService : IDisposable
             var enabled = profile.Badges.Where(b => IsBadgeEnabled(b.Id)).ToList();
             var unlocked = enabled.Count(b => b.Unlocked);
             var total = enabled.Count;
+            // [issue #42] Same two fields the leaderboard publishes.
+            var cosmetics = BuildPublicCosmetics(profile);
 
             return new
             {
@@ -2669,7 +2739,9 @@ public class AchievementBadgeService : IDisposable
                 Percentage = total == 0 ? 0 : Math.Round((double)unlocked / total * 100.0, 1),
                 Score = AchievementScoreHelper.GetTotalUnlockedScore(enabled),
                 BestWatchStreak = profile.Counters.BestWatchStreak,
-                Equipped = BuildEquippedPreview(profile)
+                Equipped = BuildEquippedPreview(profile),
+                CustomTitle = cosmetics.CustomTitle,
+                BadgeFrameId = cosmetics.BadgeFrameId
             };
         }
     }

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Big thanks to **[@camarigor](https://github.com/camarigor)** for the friend prof
 - **8 book badges (v2.1.0)** — books completed, audiobook listening hours, and series completed. Audiobook plays route per the **audiobook-counting policy** (Books-only default / Music-only / Both).
 - **Improved anime detection (v2.1.0, #25)** — matches **Genres *and* Tags** on the item *and its parent Series*, with admin-configurable libraries / genres / tags.
 - **Admin-authored custom badges (v2.1.0)** — compound AND/OR criteria across any metric; see [Custom badges](#-custom-badges).
-- **Targeted badges (v2.4.0, #107)** — point a badge at one specific series, season, collection, playlist, album or item; see [Targeted badges](#targeted-badges).
+- **Targeted badges (v2.4.0, #107)**: point a badge at one specific series, season, collection, playlist, album or item; see [Targeted badges](#targeted-badges).
+- **Shop cosmetics on the shareable card (v2.4.0, #42)**: the equipped custom title and badge frame show on the shareable profile card and on the friends-drawer profile card, under the same privacy toggles as the equipped badges.
 - **6 rarity tiers** — Common, Uncommon, Rare, Epic, Legendary, Mythic
 - **Hidden/secret badges** displayed as `???` until unlocked
 - **Library completion milestones** that auto-scale to any library structure

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -14,6 +14,14 @@ Requested by **@unknownTGG** in #107.
 - **Moves on manual marking, not only on playback.** The trigger is Jellyfin's own played flag, so marking a season watched by hand advances the badge. That is how an old arc actually gets completed.
 - **Bounded cost.** Only the targets that enabled badges actually reference are ever computed. `MaxTargetedBadgeTargets` (default 50) caps how many, and targets past the cap are named in the log rather than dropped silently.
 
+## Added - shop bling on the shareable card
+
+Asked by **@TsunamicFlame** in #42: the shop sold a custom title and a badge frame that only their owner could see.
+
+- **The equipped custom title and badge frame now show on the shareable profile card**, on all three skins, and on the profile card that opens from the friends drawer. The title sits under the name, star prefixed, in the skin's accent; the frame recolours the equipped badges.
+- **Same privacy as the equipped badges.** Both are hidden by the same toggles that hide the equipped preview (showcase off, hidden from leaderboard or compare, admin force-hide), and privacy mode hides everything. Both are resolved against the shop catalog, so a stale or unknown id shows nothing.
+- **Not the profile theme.** The card skins are drawn in the rank tier's colour; painting them in the owner's theme is a redesign of the three templates and is left for a follow-up.
+
 ## Changed
 
 - The `library-completion/recompute` endpoint now also recomputes targeted progress and returns it, so a broken or unwanted scan does not leave targeted badges unreachable.


### PR DESCRIPTION
Follows up on #42, the last comment there.

@TsunamicFlame bought the "Tastemaker" title and the "Gilded" badge frame and found that nobody else could see either: the shareable profile card and the profile card in the friends drawer both ignore what the owner equipped. He asked whether he had misunderstood the point of the shop. He had not. The profile stores six equipped cosmetic ids and neither public surface reads any of them; the shop was built for the owner's own page, and the cards were built later from the stats summary, and the two were never connected.

This PR connects the two for the custom title and the badge frame.

## What changed

**Server**

- `PublicCosmetics` (new): the equipped custom title and badge frame a user shows to others. Resolved against the shop catalog, so a stale, renamed or hand-edited id becomes nothing rather than markup, and `frame-default` reads as no frame since it is what everyone has.
- The privacy gate the equipped badge preview already used (showcase off, hidden from leaderboard or compare, admin force-hide) moves into a shared `ShowcaseHidden` and now covers the title and frame too. A user who hid their showcase gets a plain card, bling included. Privacy mode hides everything, and an unknown user reads the same as a hidden one.
- `CustomTitle` and `BadgeFrameId` are published on the global leaderboard first and repeated in the public summary. `PublicProfileSummaryTests` pins the rule that the summary never exposes more than the leaderboard does; I kept that rule and extended the pinned list.
- The `profile-card` endpoint receives `{{customTitle}}` and `{{frameClass}}`, both HTML-encoded.

**Shareable card, all three skins**

- The title sits under the owner's name, star prefixed, in the skin's own accent (tier colour on Console and Aurora, the green of Metro). The line collapses with `:empty` when nothing is equipped, which only works because the token is placed with no whitespace inside the element; the CSS comment says so.
- The frame lands as a class on the equipped container and recolours the badge chips with the same six frame colours the achievements page uses.

**Friends drawer**

- Both profile card renderers show the title under the name and paint the equipped badge dots' ring in the frame colour, keeping the rarity colour as the fill. Unknown frame ids fall back to the rarity ring.

**Not done, on purpose**

- The profile theme ("Pastel" in the report) is not painted on the card. The three skins are designed around the rank tier's colour, and painting them in the owner's theme is a redesign of the templates, not a projection of data. I would rather do that as its own change with the maintainer's eye on the look.
- The "un-hidden elements" remark about the Pastel theme in the same comment is not addressed here: the theme's CSS only recolours backgrounds, borders and the hero title, and I could not tell from the description what was showing that should not. I asked for a screenshot on the issue.

## Verification

| Check | Result |
| --- | --- |
| Test suite | 240/240 (six new in `PublicCosmeticsTests`) |
| Release build with analyzers as errors | clean |
| The reporter's exact case (`title-tastemaker` + `frame-gilded`) | card and summary both return "Tastemaker" and `frame-gilded` |
| Showcase hidden | both null |
| `frame-default`, unknown title id, a title id passed as a frame | all null |
| No `ShopService` injected | nothing shows, nothing throws |
| All three skins rendered in a browser with cosmetics | title visible with the star, `.eq` carries `frame-gilded`, chip border computes to `rgb(250, 204, 21)` |
| All three skins rendered without cosmetics | title line `display: none`, chips keep their default border |
| Drawer dot renderer, run under Node with stubs | rarity ring without a frame, `#facc15` ring with `frame-gilded`, rarity ring for an unknown id |
| `node --check` on `sidebar.js` | passes |

The unreleased v2.4.0 note and the README record the change. I also replaced an em dash I had put in the README's targeted-badges bullet with a colon.
