### PR TITLE
feat: achievements for games played through JellyEmu (#115)

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/DataResilienceTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/DataResilienceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using Jellyfin.Plugin.AchievementBadges.Configuration;
 using Jellyfin.Plugin.AchievementBadges.Helpers;
 using Jellyfin.Plugin.AchievementBadges.Models;
@@ -120,6 +121,33 @@ public class DataResilienceTests : IDisposable
         Assert.Equal(4, rebuilt.GenreItemCounts["Horror"]);
         Assert.Equal(8, rebuilt.GenreItemCounts["Comedy"]);
         Assert.Equal(7200, rebuilt.MusicGenreListeningSeconds["Jazz"]);
+    }
+
+    [Fact]
+    public void CounterFloor_PerKeySets_UnionPerKey()
+    {
+        // Issue #115. A game session leaves no played flag behind, so a
+        // watch history rebuild produces empty game sets. Before the floor
+        // learned this shape, one scan wiped every platform and studio a
+        // player had touched while the plain totals next to them survived.
+        var previous = new UserAchievementCounters { GamePlays = 12, GamePlaySeconds = 5400 };
+        previous.GamesByPlatform["SNES"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "mario", "zelda" };
+        previous.GamesByPlatform["SegaGenesis"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "sonic" };
+        previous.GamesByStudio["Nintendo"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "mario", "zelda" };
+
+        var rebuilt = new UserAchievementCounters();
+        rebuilt.GamesByPlatform["SNES"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "metroid" };
+
+        CounterFloor.Apply(previous, rebuilt);
+
+        Assert.Equal(12, rebuilt.GamePlays);
+        Assert.Equal(5400, rebuilt.GamePlaySeconds);
+        Assert.Equal(2, rebuilt.UniqueGamePlatforms);
+        Assert.Equal(new[] { "mario", "metroid", "zelda" }, rebuilt.GamesByPlatform["SNES"].OrderBy(g => g).ToArray());
+        Assert.Equal(new[] { "sonic" }, rebuilt.GamesByPlatform["SegaGenesis"].ToArray());
+        // The copied set keeps its comparer, so the case-insensitive lookup still works.
+        Assert.True(rebuilt.GamesByPlatform["SegaGenesis"].Contains("SONIC"));
+        Assert.Equal(2, rebuilt.GamesByStudio["Nintendo"].Count);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.AchievementBadges.Tests/GameAchievementTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/GameAchievementTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Linq;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #115. A game session credited through the same RecordPlayback path
+/// every other media kind uses. These pin what a session adds to the game
+/// counters, what it must not add to (books), and that the parameterised
+/// game metrics read those counters the way a custom badge would.
+/// </summary>
+public class GameAchievementTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly AchievementBadgeService _badges;
+    private readonly CustomBadgeService _customBadges;
+
+    private static readonly Guid Player = Guid.Parse("99999999-1111-2222-3333-444444444444");
+    private static readonly Guid Mario = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly Guid Zelda = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002");
+    private static readonly Guid Sonic = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000003");
+
+    private string PlayerId => Player.ToString("D");
+
+    public GameAchievementTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "abgames_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var paths = new Mock<IApplicationPaths>();
+        paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        var users = new Mock<IUserManager>();
+        users.Setup(m => m.GetUserById(Player)).Returns(new User("Player", "prov", "reset"));
+
+        _customBadges = new CustomBadgeService(paths.Object, NullLogger<CustomBadgeService>.Instance);
+        _badges = new AchievementBadgeService(
+            paths.Object,
+            users.Object,
+            new WebhookNotifier(NullLogger<WebhookNotifier>.Instance),
+            new AuditLogService(paths.Object, NullLogger<AuditLogService>.Instance),
+            NullLogger<AchievementBadgeService>.Instance,
+            customBadges: _customBadges);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private void Play(Guid game, string platform, long seconds, params string[] studios)
+    {
+        _badges.RecordPlayback(new PlaybackContext
+        {
+            UserId = PlayerId,
+            ItemId = game.ToString("D"),
+            IsGame = true,
+            GamePlatform = platform,
+            GamePlaySeconds = seconds,
+            Studios = studios,
+            LibraryName = "Video Games",
+            Silent = true
+        });
+    }
+
+    [Fact]
+    public void ASessionFeedsEveryGameCounterAndNoBookCounter()
+    {
+        Play(Mario, "SNES", 3600, "Nintendo");
+        Play(Mario, "SNES", 1800, "Nintendo");
+        Play(Zelda, "SNES", 7200, "Nintendo");
+        Play(Sonic, "SegaGenesis", 600, "Sega", "Sega Technical Institute");
+
+        var c = _badges.PeekProfile(PlayerId)!.Counters;
+        Assert.Equal(4, c.GamePlays);
+        Assert.Equal(13200, c.GamePlaySeconds);
+        Assert.Equal(3, c.GamePlayHours);
+        Assert.Equal(3, c.UniqueGamesPlayed);
+        Assert.Equal(2, c.UniqueGamePlatforms);
+        Assert.Equal(5400, c.GameSecondsByItem[Mario.ToString("N")]);
+        Assert.Equal(2, c.GamesByPlatform["SNES"].Count);
+        Assert.Equal(2, c.GamesByStudio["Nintendo"].Count);
+        Assert.Equal(1, c.GamesByStudio["Sega Technical Institute"].Count);
+
+        // The item is a Book in Jellyfin's eyes. It must not read as one here.
+        Assert.Equal(0, c.BooksCompleted);
+    }
+
+    [Fact]
+    public void AnUnknownPlatformIsNotAPlatform()
+    {
+        Play(Mario, "Unknown", 3600);
+        Play(Zelda, null!, 3600);
+
+        var c = _badges.PeekProfile(PlayerId)!.Counters;
+        Assert.Equal(2, c.UniqueGamesPlayed);
+        Assert.Equal(0, c.UniqueGamePlatforms);
+    }
+
+    [Fact]
+    public void TheGameMetricsAreAppendedAtTheEndOfTheEnum()
+    {
+        var values = (AchievementMetric[])Enum.GetValues(typeof(AchievementMetric));
+        var last = values.Skip(values.Length - 7).ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                AchievementMetric.GamePlays, AchievementMetric.GamePlayHours, AchievementMetric.UniqueGamesPlayed,
+                AchievementMetric.UniqueGamePlatforms, AchievementMetric.GamePlatformGames, AchievementMetric.GameStudioGames,
+                AchievementMetric.GameHours
+            },
+            last);
+        Assert.Equal(AchievementMetric.ItemPlayCount, values[^8]);
+    }
+
+    [Fact]
+    public void ParameterisedGameMetricsUnlockCustomBadges()
+    {
+        // The reporter's own wording: "You've played X games by Developer",
+        // plus hours in one specific game, both as custom badges. The platform
+        // parameter is matched case-insensitively, like music genres.
+        _customBadges.Upsert(new CustomBadge
+        {
+            Id = "sega-fan",
+            Name = "Sega Fan",
+            Criteria = new CustomBadgeCriteria { Metric = AchievementMetric.GamePlatformGames, MetricParameter = "segagenesis", Threshold = 2 }
+        });
+        _customBadges.Upsert(new CustomBadge
+        {
+            Id = "nintendo-two",
+            Name = "Two by Nintendo",
+            Criteria = new CustomBadgeCriteria { Metric = AchievementMetric.GameStudioGames, MetricParameter = "Nintendo", Threshold = 2 }
+        });
+        _customBadges.Upsert(new CustomBadge
+        {
+            Id = "mario-hour",
+            Name = "An hour of Mario",
+            Criteria = new CustomBadgeCriteria { Metric = AchievementMetric.GameHours, MetricParameter = Mario.ToString("N") + "|Super Mario World", Threshold = 1 }
+        });
+
+        Play(Mario, "SNES", 1800, "Nintendo");
+        Play(Zelda, "SNES", 600, "Nintendo");
+        Play(Sonic, "SegaGenesis", 600, "Sega");
+
+        var badges = _badges.PeekProfile(PlayerId)!.Badges;
+        Assert.True(badges.Single(b => b.Id == "nintendo-two").Unlocked);
+        Assert.False(badges.Single(b => b.Id == "sega-fan").Unlocked);
+        Assert.False(badges.Single(b => b.Id == "mario-hour").Unlocked);
+
+        Play(Mario, "SNES", 1800, "Nintendo");
+        Assert.True(_badges.PeekProfile(PlayerId)!.Badges.Single(b => b.Id == "mario-hour").Unlocked);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/GameSessionPipelineTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/GameSessionPipelineTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Jellyfin.Plugin.AchievementBadges.Services;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #115. The completion service credits movies through a gate (80%
+/// watched) and a dedupe (same item within six hours). Neither fits a game
+/// session: there is no 80% of a game, and the same game twice in an evening
+/// is two sessions. These pin the game path that skips both while keeping
+/// the rate guards, and pin that the movie path still dedupes after the
+/// guards were extracted.
+/// </summary>
+public class GameSessionPipelineTests : IDisposable
+{
+    private readonly string _dataDir;
+    private readonly AchievementBadgeService _badges;
+    private readonly PlaybackCompletionService _completion;
+
+    private static readonly Guid Player = Guid.Parse("99999999-5555-6666-7777-888888888888");
+    private static readonly Guid Mario = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000001");
+    private string PlayerId => Player.ToString("D");
+
+    public GameSessionPipelineTests()
+    {
+        _dataDir = Path.Combine(Path.GetTempPath(), "abpipe_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dataDir);
+
+        var paths = new Mock<IApplicationPaths>();
+        paths.SetupGet(p => p.PluginConfigurationsPath).Returns(_dataDir);
+
+        _badges = new AchievementBadgeService(
+            paths.Object,
+            new Mock<IUserManager>().Object,
+            new WebhookNotifier(NullLogger<WebhookNotifier>.Instance),
+            new AuditLogService(paths.Object, NullLogger<AuditLogService>.Instance),
+            NullLogger<AchievementBadgeService>.Instance);
+        _completion = new PlaybackCompletionService(_badges, paths.Object);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dataDir, recursive: true); } catch { /* best effort */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private static PlaybackContext Session(long seconds) => new()
+    {
+        UserId = Player.ToString("D"),
+        ItemId = Mario.ToString("D"),
+        IsGame = true,
+        GamePlatform = "SNES",
+        GamePlaySeconds = seconds,
+        Studios = new[] { "Nintendo" },
+        Silent = true
+    };
+
+    [Fact]
+    public void TheSameGameTwiceInAnEveningIsTwoSessions()
+    {
+        // The exact thing the movie path would refuse: the second play of
+        // the same item within six hours.
+        Assert.True(_completion.RecordGameSession(Session(1800), out _));
+        Assert.True(_completion.RecordGameSession(Session(2400), out var message), message);
+
+        var c = _badges.PeekProfile(PlayerId)!.Counters;
+        Assert.Equal(2, c.GamePlays);
+        Assert.Equal(4200, c.GamePlaySeconds);
+        Assert.Equal(1, c.UniqueGamesPlayed);
+    }
+
+    [Fact]
+    public void ASessionWithNoSecondsIsRefused()
+    {
+        // Zero is what the tracker hands over when the clamp floor was not
+        // met. It must not become a play with no time.
+        Assert.False(_completion.RecordGameSession(Session(0), out var message));
+        Assert.Contains("short", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(_badges.PeekProfile(PlayerId));
+    }
+
+    [Fact]
+    public void ANonGameContextIsRefusedByTheGamePath()
+    {
+        var movie = Session(1800);
+        movie.IsGame = false;
+        movie.IsMovie = true;
+
+        Assert.False(_completion.RecordGameSession(movie, out var message));
+        Assert.Contains("Not a game", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheMoviePathStillDedupesAfterTheGuardsMoved()
+    {
+        // Regression guard for the extraction: the six-hour per-item dedupe
+        // and the completion gate stayed on the movie path.
+        var movie = new PlaybackContext { UserId = PlayerId, ItemId = Mario.ToString("D"), IsMovie = true, Silent = true };
+
+        Assert.True(_completion.RecordCompletion(movie, 95, out _));
+        Assert.False(_completion.RecordCompletion(movie, 95, out var again));
+        Assert.Contains("already counted", again, StringComparison.OrdinalIgnoreCase);
+        Assert.False(_completion.RecordCompletion(new PlaybackContext { UserId = PlayerId, ItemId = Guid.NewGuid().ToString("D"), IsMovie = true }, 40, out var low));
+        Assert.Contains("80%", low, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheTrackerHasAGameSessionPath()
+    {
+        // The two video checks that dropped game sessions live in the
+        // tracker's stop handler. A dedicated path is the fix; losing it
+        // brings the silent drop back with no test failing anywhere else.
+        var method = typeof(PlaybackCompletionTracker)
+            .GetMethod("RecordGameSession", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        Assert.Contains(method!.GetParameters(), p => p.ParameterType == typeof(MediaBrowser.Controller.Entities.BaseItem));
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/GameSessionTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/GameSessionTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.AchievementBadges.Helpers;
+using Jellyfin.Plugin.AchievementBadges.Models;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Issue #115. Jellyfin has no game type: JellyEmu stores games as Book
+/// items. These pin the three decisions that keep a game from being an
+/// ebook and an ebook from being a game, the platform reading, and the
+/// session clamp that stands in for the video accumulator, which cannot
+/// measure a game (it would read every 30-second progress ping as a seek).
+/// </summary>
+public class GameSessionTests
+{
+    private static IReadOnlyList<string> Tags(params string[] tags) => tags;
+
+    private static IReadOnlyDictionary<string, string> Providers(params string[] keys)
+    {
+        var d = new Dictionary<string, string>();
+        foreach (var k in keys) d[k] = "1";
+        return d;
+    }
+
+    [Fact]
+    public void AJellyEmuTaggedBookIsAGame()
+    {
+        // LocalRomProvider writes "JellyEmu", "Game" and the platform on
+        // every ROM. Either of the first two is enough.
+        Assert.True(GameSession.IsGame(Tags("JellyEmu", "Game", "SNES", "USA"), null));
+        Assert.True(GameSession.IsGame(Tags("Game"), null));
+        Assert.True(GameSession.IsGame(Tags("jellyemu"), null));
+    }
+
+    [Fact]
+    public void AGameProviderIdIsEnoughWithoutTags()
+    {
+        // The metadata providers write these; a hand-edited item that lost
+        // its tags still reads as a game.
+        Assert.True(GameSession.IsGame(null, Providers("IGDB")));
+        Assert.True(GameSession.IsGame(null, Providers("RAWG")));
+        Assert.True(GameSession.IsGame(null, Providers("MD5", "RetroAchievements")));
+    }
+
+    [Fact]
+    public void AnEbookStaysAnEbook()
+    {
+        // The case that matters most: an ordinary Books library must not
+        // start producing game badges.
+        Assert.False(GameSession.IsGame(null, null));
+        Assert.False(GameSession.IsGame(Tags("Fiction", "Audiobook"), Providers("ISBN", "GoogleBooks")));
+    }
+
+    [Fact]
+    public void ThePlatformIsTheTagThatNamesOne()
+    {
+        // Regions and disc markers sit next to the platform tag and must not
+        // be mistaken for it. The canonical spelling is JellyEmu's.
+        Assert.Equal("SNES", GameSession.Platform(Tags("JellyEmu", "Game", "USA", "SNES", "Disc 1")));
+        Assert.Equal("GameBoyAdvance", GameSession.Platform(Tags("gameboyadvance")));
+        Assert.Equal(GameSession.UnknownPlatform, GameSession.Platform(Tags("JellyEmu", "Game", "Europe")));
+        Assert.Equal(GameSession.UnknownPlatform, GameSession.Platform(null));
+    }
+
+    [Fact]
+    public void SessionLengthIsTheSmallerOfClientAndOwnClock()
+    {
+        // The client's elapsed time is trusted only as far as this plugin's
+        // own clock agrees: a client claiming 3 hours after 40 minutes of
+        // wall time gets 40 minutes.
+        Assert.Equal(2400, GameSession.ClampSeconds(reportedSeconds: 10800, wallClockSeconds: 2400, minSeconds: 60, maxSeconds: 21600));
+        Assert.Equal(1800, GameSession.ClampSeconds(1800, 2400, 60, 21600));
+    }
+
+    [Fact]
+    public void TooShortIsNothingAndTooLongIsTheCap()
+    {
+        // A launch closed at once is not a play; a tab left open overnight
+        // counts as the cap, not the night.
+        Assert.Equal(0, GameSession.ClampSeconds(45, 45, 60, 21600));
+        Assert.Equal(21600, GameSession.ClampSeconds(40000, 40000, 60, 21600));
+        Assert.Equal(0, GameSession.ClampSeconds(-5, 300, 60, 21600));
+    }
+
+    [Fact]
+    public void GameIsAppendedToMediaTypeAndTheCountersRoundTrip()
+    {
+        // MediaType is stored by ordinal on every badge definition.
+        Assert.Equal(6, (int)MediaType.Game);
+
+        var counters = new UserAchievementCounters();
+        Assert.Equal(0, counters.UniqueGamesPlayed);
+        Assert.Equal(0, counters.GamePlayHours);
+
+        counters.GamePlays = 3;
+        counters.GamePlaySeconds = 7200;
+        counters.GamesPlayed.Add("a");
+        counters.GamesPlayed.Add("b");
+        counters.GamesByPlatform["SNES"] = new HashSet<string> { "a", "b" };
+        counters.GameSecondsByItem["a"] = 5400;
+        counters.GamesByStudio["Capcom"] = new HashSet<string> { "a", "b" };
+
+        Assert.Equal(2, counters.UniqueGamesPlayed);
+        Assert.Equal(1, counters.UniqueGamePlatforms);
+        Assert.Equal(2, counters.GamesByPlatform["SNES"].Count);
+        Assert.Equal(2, counters.GamePlayHours);
+        Assert.Equal(2, counters.GamesByStudio["Capcom"].Count);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/TargetedMetricTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/TargetedMetricTests.cs
@@ -57,16 +57,17 @@ public class TargetedMetricTests : IDisposable
     }
 
     [Fact]
-    public void TheNewMetricsAreAppendedAtTheEndOfTheEnum()
+    public void TheTargetedMetricsKeepTheirOrdinals()
     {
-        // Ordinals are serialized. Inserting these anywhere but the end
-        // silently reinterprets every stored badge definition past the
-        // insertion point.
-        var values = (AchievementMetric[])Enum.GetValues(typeof(AchievementMetric));
-
-        Assert.Equal(AchievementMetric.ItemPlayCount, values[^1]);
-        Assert.Equal(AchievementMetric.ContainerCompletionPercent, values[^2]);
-        Assert.Equal(AchievementMetric.ArtistCompletionPercent, values[^3]);
+        // Ordinals are serialized. Inserting a value before these silently
+        // reinterprets every stored badge definition past the insertion
+        // point. This used to assert the two metrics were LAST in the enum,
+        // which is a proxy for that invariant and fails on every correct
+        // append after them (issue #115 added seven). Pinning the ordinals
+        // tests the thing that actually matters.
+        Assert.Equal(70, (int)AchievementMetric.ArtistCompletionPercent);
+        Assert.Equal(71, (int)AchievementMetric.ContainerCompletionPercent);
+        Assert.Equal(72, (int)AchievementMetric.ItemPlayCount);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/PluginConfiguration.cs
@@ -224,4 +224,17 @@ public class PluginConfiguration : BasePluginConfiguration
     /// silently.
     /// </summary>
     public int MaxTargetedBadgeTargets { get; set; } = 50;
+
+    /// <summary>
+    /// [issue #115] A game session shorter than this counts for nothing: a
+    /// launch closed at once is not a play.
+    /// </summary>
+    public int MinGameSessionSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// [issue #115] A game session counts for at most this long. JellyEmu
+    /// keeps reporting for as long as the tab is open, so without a cap a
+    /// browser left running overnight would be a night of play time.
+    /// </summary>
+    public int MaxGameSessionMinutes { get; set; } = 360;
 }

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
@@ -355,6 +355,7 @@
                                 <option value="TV">TV</option>
                                 <option value="Music">Music</option>
                                 <option value="Book">Book</option>
+                                <option value="Game">Game (JellyEmu)</option>
                                 <option value="Anime">Anime</option>
                                 <option value="Multi" selected>Multi</option>
                             </select>
@@ -386,6 +387,13 @@
                                 <option value="UniqueCountriesWatched">Unique countries watched</option>
                                 <option value="ContainerCompletionPercent" data-param="target" data-target-kinds="Series,Season,BoxSet,Playlist,MusicAlbum">Completion of one series, season or collection&hellip;</option>
                                 <option value="ItemPlayCount" data-param="target" data-target-kinds="Movie,Episode,Audio,Book">Plays of one specific item&hellip;</option>
+                                <option value="GamePlays">Game sessions played (JellyEmu)</option>
+                                <option value="GamePlayHours">Game hours played (JellyEmu)</option>
+                                <option value="UniqueGamesPlayed">Different games played (JellyEmu)</option>
+                                <option value="UniqueGamePlatforms">Different game platforms played (JellyEmu)</option>
+                                <option value="GamePlatformGames" data-param="platform">Different games on a platform&hellip;</option>
+                                <option value="GameStudioGames" data-param="studio">Different games from a developer or publisher&hellip;</option>
+                                <option value="GameHours" data-param="target" data-target-kinds="Book" data-target-tags="JellyEmu">Hours in one specific game&hellip;</option>
                             </select>
                         </div>
                         <div class="inputContainer" id="NewBadgeParamRow" style="display:none;">
@@ -543,7 +551,7 @@
                 // The option value is the "{guid}|{name}" pair the server
                 // stores: the GUID survives a rename, the name survives an item
                 // being deleted and re-added, and each covers the other.
-                searchBadgeTargets: function (term, kinds) {
+                searchBadgeTargets: function (term, kinds, tags) {
                     var results = document.getElementById('NewBadgeTargetResults');
                     if (!results) return Promise.resolve([]);
                     if (!term || term.length < 2) {
@@ -553,7 +561,8 @@
 
                     var query = 'Items?Recursive=true&Limit=25&SearchTerm='
                         + encodeURIComponent(term)
-                        + '&IncludeItemTypes=' + encodeURIComponent(kinds);
+                        + '&IncludeItemTypes=' + encodeURIComponent(kinds)
+                        + (tags ? '&Tags=' + encodeURIComponent(tags) : '');
 
                     return fetch(this.getApiUrl(query), {
                         headers: this.getAuthHeaders(),
@@ -1089,7 +1098,20 @@
                 if (label) { label.style.display = isTarget ? 'none' : ''; }
                 if (desc) { desc.style.display = isTarget ? 'none' : ''; }
 
+                // [issue #115] The same text field carries a genre, a platform
+                // tag or a studio name depending on the metric; say which.
+                var wording = {
+                    platform: ['Platform tag', 'The platform tag JellyEmu puts on the game (case-insensitive), e.g. SNES or SegaGenesis.', 'e.g. SNES'],
+                    studio: ['Developer or publisher', 'A studio name as it appears on the game (case-insensitive), e.g. Nintendo.', 'e.g. Capcom']
+                }[param];
                 var text = document.getElementById('NewBadgeParam');
+                [[label, 'textContent', 0], [desc, 'textContent', 1], [text, 'placeholder', 2]].forEach(function (slot) {
+                    var el = slot[0];
+                    if (!el) return;
+                    if (el._abDefault === undefined) { el._abDefault = el[slot[1]]; }
+                    el[slot[1]] = wording ? wording[slot[2]] : el._abDefault;
+                });
+
                 if (text) {
                     text.style.display = isTarget ? 'none' : '';
                     if (!needs || isTarget) { text.value = ''; }
@@ -1109,7 +1131,8 @@
                         var current = document.getElementById('NewBadgeMetric');
                         var currentOpt = current.options[current.selectedIndex];
                         var kinds = (currentOpt && currentOpt.getAttribute('data-target-kinds')) || '';
-                        AchievementBadgesConfig.searchBadgeTargets(search.value.trim(), kinds);
+                        var tags = (currentOpt && currentOpt.getAttribute('data-target-tags')) || '';
+                        AchievementBadgesConfig.searchBadgeTargets(search.value.trim(), kinds, tags);
                     });
                 }
             }

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/CounterFloor.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/CounterFloor.cs
@@ -103,6 +103,23 @@ public static class CounterFloor
                     }
                 }
             }
+            else if (property.GetValue(previous) is Dictionary<string, HashSet<string>> prevSets && property.GetValue(rebuilt) is Dictionary<string, HashSet<string>> currSets)
+            {
+                // [issue #115] Per key sets (games per platform, games per
+                // studio). A game session leaves no played flag behind, so a
+                // rebuild never sees it and the sets must union per key.
+                foreach (var (key, values) in prevSets)
+                {
+                    if (currSets.TryGetValue(key, out var existing))
+                    {
+                        existing.UnionWith(values);
+                    }
+                    else
+                    {
+                        currSets[key] = new HashSet<string>(values, values.Comparer);
+                    }
+                }
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.AchievementBadges/Helpers/GameSession.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Helpers/GameSession.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.AchievementBadges.Helpers;
+
+/// <summary>
+/// [issue #115] What makes a Jellyfin item a game, which platform it is on,
+/// and how long a game session counts for. Pure, so it can be tested without
+/// a library.
+/// <para>
+/// Jellyfin has no game item type. JellyEmu stores every ROM as a
+/// <c>Book</c> in a Books library and tags it with <c>JellyEmu</c>,
+/// <c>Game</c> and the platform (LocalRomProvider), and its metadata
+/// providers write IGDB / RAWG / RetroAchievements provider ids. An ebook has
+/// none of that, so those markers are what tells the two apart.
+/// </para>
+/// <para>
+/// Play time is not the video accumulator's job. JellyEmu reports a session's
+/// elapsed wall-clock time as the playback position, which the video path
+/// would read as one 30-second seek after another and discard. A game session
+/// is measured as the smaller of what the client reported and what this
+/// plugin saw on its own clock, bounded on both ends: below the floor it is a
+/// misclick, above the cap it is a tab left open.
+/// </para>
+/// </summary>
+public static class GameSession
+{
+    public const string JellyEmuTag = "JellyEmu";
+    public const string GameTag = "Game";
+    public const string UnknownPlatform = "Unknown";
+
+    private static readonly string[] GameProviderKeys = { "IGDB", "RAWG", "RetroAchievements" };
+
+    /// <summary>
+    /// The platform tags JellyEmu's PlatformResolver can write, both the ones
+    /// its web emulator runs and the library-only ones. Anything else on an
+    /// item is a region, a disc marker or a user tag, not a platform.
+    /// </summary>
+    public static IReadOnlySet<string> Platforms => PlatformSet;
+
+    // HashSet rather than the read-only interface because TryGetValue, which
+    // hands back the canonical spelling for a case-insensitive hit, lives on
+    // the concrete type only.
+    private static readonly HashSet<string> PlatformSet = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "3DO", "Arcade", "Atari2600", "Atari5200", "Atari7800", "AtariJaguar", "AtariLynx",
+        "ColecoVision", "Commodore64", "CommodoreAmiga", "DOS", "GameBoy", "GameBoyAdvance",
+        "GameBoyColor", "GameGear", "MAME2003", "MasterSystem", "N64", "NeoGeoPocket", "NES",
+        "Nintendo3DS", "NintendoDS", "PC-FX", "PICO-8", "PlayStation", "PSP", "Sega32X", "SegaCD",
+        "SegaGenesis", "SegaSaturn", "SNES", "TurboGrafx-16", "VirtualBoy", "WonderSwan",
+        "Dreamcast", "GameCube", "NintendoSwitch", "PlayStation2", "PlayStation3", "PlayStationVita",
+        "Wii", "WiiU", "Windows", "Xbox", "Xbox360",
+    };
+
+    public static bool IsGame(IReadOnlyList<string>? tags, IReadOnlyDictionary<string, string>? providerIds)
+    {
+        if (tags is not null)
+        {
+            foreach (var tag in tags)
+            {
+                if (string.Equals(tag, JellyEmuTag, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(tag, GameTag, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (providerIds is not null)
+        {
+            foreach (var key in providerIds.Keys)
+            {
+                foreach (var gameKey in GameProviderKeys)
+                {
+                    if (string.Equals(key, gameKey, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The first tag that names a known platform, in JellyEmu's canonical
+    /// spelling, or <see cref="UnknownPlatform"/>. Unknown never counts as a
+    /// distinct platform.
+    /// </summary>
+    public static string Platform(IReadOnlyList<string>? tags)
+    {
+        if (tags is null)
+        {
+            return UnknownPlatform;
+        }
+
+        foreach (var tag in tags)
+        {
+            if (PlatformSet.TryGetValue(tag, out var canonical))
+            {
+                return canonical;
+            }
+        }
+
+        return UnknownPlatform;
+    }
+
+    /// <summary>
+    /// Seconds a session counts for. Zero when the session is shorter than
+    /// <paramref name="minSeconds"/> (a launch that was closed at once), and
+    /// never more than <paramref name="maxSeconds"/> (a tab left open). The
+    /// client's number is trusted only as far as this plugin's own clock
+    /// agrees with it.
+    /// </summary>
+    public static long ClampSeconds(long reportedSeconds, long wallClockSeconds, long minSeconds, long maxSeconds)
+    {
+        var seconds = Math.Min(Math.Max(reportedSeconds, 0), Math.Max(wallClockSeconds, 0));
+        if (seconds < Math.Max(minSeconds, 0))
+        {
+            return 0;
+        }
+
+        return maxSeconds > 0 ? Math.Min(seconds, maxSeconds) : seconds;
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges/Models/AchievementMetric.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/AchievementMetric.cs
@@ -102,4 +102,19 @@ public enum AchievementMetric
     // existing serialized ordinals must not shift.
     ContainerCompletionPercent,
     ItemPlayCount,
+
+    // [issue #115] Games played through JellyEmu. Plays and hours are
+    // totals; the Unique ones count distinct games and platforms;
+    // GamePlatformGames and GameStudioGames take the platform tag or the
+    // developer/publisher as MetricParameter; GameHours takes a target
+    // ("{guid:N}|{name}", see Helpers/TargetRef) and reads the hours in that
+    // one game. Appended at the end: existing serialized ordinals must not
+    // shift.
+    GamePlays,
+    GamePlayHours,
+    UniqueGamesPlayed,
+    UniqueGamePlatforms,
+    GamePlatformGames,
+    GameStudioGames,
+    GameHours,
 }

--- a/Jellyfin.Plugin.AchievementBadges/Models/MediaType.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/MediaType.cs
@@ -20,4 +20,9 @@ public enum MediaType
     Book = 3,
     Anime = 4,
     Multi = 5,
+    // [issue #115] Games played through JellyEmu. Jellyfin stores them as
+    // Book items; the plugin tells them apart by the tags and provider ids
+    // JellyEmu writes (see Helpers/GameSession). Appended so stored ordinals
+    // do not move.
+    Game = 6,
 }

--- a/Jellyfin.Plugin.AchievementBadges/Models/PlaybackContext.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/PlaybackContext.cs
@@ -26,6 +26,15 @@ public class PlaybackContext
     public bool IsAudiobook { get; set; }
     public bool IsBook { get; set; }
 
+    // [issue #115] A game session reported by JellyEmu. The item is a Book
+    // in Jellyfin's eyes, so IsBook stays false on these: a game is not a
+    // finished ebook. GamePlaySeconds is the session length after the clamp
+    // in Helpers/GameSession; GamePlatform is JellyEmu's canonical platform
+    // tag or "Unknown".
+    public bool IsGame { get; set; }
+    public string? GamePlatform { get; set; }
+    public long GamePlaySeconds { get; set; }
+
     // Music-specific metadata (null on non-music plays).
     public string? Album { get; set; }
     public IReadOnlyList<string>? Artists { get; set; }

--- a/Jellyfin.Plugin.AchievementBadges/Models/UserAchievementCounters.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Models/UserAchievementCounters.cs
@@ -88,6 +88,25 @@ public class UserAchievementCounters
     public long AudiobookListeningSeconds { get; set; }
     public HashSet<string> BookSeriesCompleted { get; set; } = new();
 
+    // [issue #115] Games played through JellyEmu. A play is one session that
+    // survived the length clamp; seconds are the clamped session lengths.
+    // GamesPlayed is a set, so "10 different games" means distinct, not
+    // repeated. GameSecondsByItem is keyed by item GUID in "N" format, the
+    // same key the targeted metrics use, so "30 hours in this game" reads
+    // straight from it. GamesByPlatform and GamesByStudio map a platform tag
+    // or a developer/publisher to the distinct games played on or from it,
+    // which is what "10 Sega games" and "5 Capcom games" count.
+    public int GamePlays { get; set; }
+    public long GamePlaySeconds { get; set; }
+    public HashSet<string> GamesPlayed { get; set; } = new();
+    public Dictionary<string, long> GameSecondsByItem { get; set; } = new();
+    public Dictionary<string, HashSet<string>> GamesByPlatform { get; set; } = new();
+    public Dictionary<string, HashSet<string>> GamesByStudio { get; set; } = new();
+
+    public int UniqueGamesPlayed => GamesPlayed.Count;
+    public int UniqueGamePlatforms => GamesByPlatform.Count;
+    public int GamePlayHours => (int)(GamePlaySeconds / 3600);
+
     public int UniqueMusicAlbumsCount => MusicAlbumsListened.Count;
     public int UniqueMusicArtistsCount => MusicArtistsListened.Count;
     public int UniqueMusicGenresCount => MusicGenresListened.Count;

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementBadgeService.cs
@@ -488,6 +488,14 @@ public class AchievementBadgeService : IDisposable
             AchievementMetric.TotalMinutesWatched => "Watch " + Math.Round(remaining / 60.0) + " more hour" + (remaining < 120 ? "" : "s"),
             AchievementMetric.DaysWatched => "Watch on " + remaining + " more day" + (remaining == 1 ? "" : "s"),
             AchievementMetric.RewatchCount => "Rewatch " + remaining + " more item" + (remaining == 1 ? "" : "s"),
+            // [issue #115] Games.
+            AchievementMetric.GamePlays => "Play " + remaining + " more game session" + (remaining == 1 ? "" : "s"),
+            AchievementMetric.GamePlayHours => "Play " + remaining + " more hour" + (remaining == 1 ? "" : "s"),
+            AchievementMetric.GameHours => "Play " + remaining + " more hour" + (remaining == 1 ? "" : "s") + " of this game",
+            AchievementMetric.UniqueGamesPlayed => "Play " + remaining + " new game" + (remaining == 1 ? "" : "s"),
+            AchievementMetric.UniqueGamePlatforms => "Play on " + remaining + " new platform" + (remaining == 1 ? "" : "s"),
+            AchievementMetric.GamePlatformGames => "Play " + remaining + " more game" + (remaining == 1 ? "" : "s") + " on this platform",
+            AchievementMetric.GameStudioGames => "Play " + remaining + " more game" + (remaining == 1 ? "" : "s") + " from this studio",
             _ => remaining + " more needed"
         };
     }
@@ -2022,6 +2030,52 @@ public class AchievementBadgeService : IDisposable
                     counters.MusicDecadesListened.Add(musicYear / 10 * 10);
             }
 
+            // [issue #115] A game session reported by JellyEmu. IsBook is
+            // false on these contexts, so a game never counts as a finished
+            // ebook; the seconds are already clamped by the tracker.
+            if (context.IsGame)
+            {
+                counters.GamePlays += creditMultiplier;
+                var gameSeconds = Math.Max(context.GamePlaySeconds, 0) * creditMultiplier;
+                counters.GamePlaySeconds += gameSeconds;
+
+                var gameKey = Guid.TryParse(context.ItemId, out var gameGuid) ? gameGuid.ToString("N") : null;
+                if (gameKey is not null)
+                {
+                    counters.GamesPlayed.Add(gameKey);
+                    counters.GameSecondsByItem.TryGetValue(gameKey, out var soFar);
+                    counters.GameSecondsByItem[gameKey] = soFar + gameSeconds;
+
+                    var platform = context.GamePlatform;
+                    if (!string.IsNullOrWhiteSpace(platform)
+                        && !string.Equals(platform, Helpers.GameSession.UnknownPlatform, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!counters.GamesByPlatform.TryGetValue(platform, out var onPlatform))
+                        {
+                            onPlatform = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                            counters.GamesByPlatform[platform] = onPlatform;
+                        }
+
+                        onPlatform.Add(gameKey);
+                    }
+
+                    // Developer and publisher both arrive as studios from the
+                    // IGDB / RAWG providers; either is a fair "games by X".
+                    foreach (var studio in context.Studios ?? Array.Empty<string>())
+                    {
+                        if (string.IsNullOrWhiteSpace(studio)) continue;
+                        var s = studio.Trim();
+                        if (!counters.GamesByStudio.TryGetValue(s, out var fromStudio))
+                        {
+                            fromStudio = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                            counters.GamesByStudio[s] = fromStudio;
+                        }
+
+                        fromStudio.Add(gameKey);
+                    }
+                }
+            }
+
             if (creditAsBook)
             {
                 counters.BooksCompleted += creditMultiplier;
@@ -3242,6 +3296,28 @@ public class AchievementBadgeService : IDisposable
                 : 0;
         }
 
+        // [issue #115] Games. The platform and studio readings match the
+        // parameter case-insensitively, like the music genre ones: "snes"
+        // and "SNES" are the same shelf. GameHours reads one target's seconds.
+        if (metric == AchievementMetric.GamePlatformGames && !string.IsNullOrWhiteSpace(parameter))
+        {
+            return LookupGameSetCount(counters.GamesByPlatform, parameter!);
+        }
+
+        if (metric == AchievementMetric.GameStudioGames && !string.IsNullOrWhiteSpace(parameter))
+        {
+            return LookupGameSetCount(counters.GamesByStudio, parameter!);
+        }
+
+        if (metric == AchievementMetric.GameHours)
+        {
+            var gameKey = Helpers.TargetRef.KeyOf(parameter);
+            return gameKey is not null
+                && counters.GameSecondsByItem.TryGetValue(gameKey, out var seconds)
+                ? (int)(seconds / 3600)
+                : 0;
+        }
+
         return GetSingleMetricValue(counters, metric);
     }
 
@@ -3308,9 +3384,28 @@ public class AchievementBadgeService : IDisposable
             AchievementMetric.BooksCompleted => counters.BooksCompleted,
             AchievementMetric.AudiobookListeningHours => counters.AudiobookListeningHours,
             AchievementMetric.UniqueBookSeriesCompleted => counters.BookSeriesCompleted.Count,
+            // [issue #115] Games.
+            AchievementMetric.GamePlays => counters.GamePlays,
+            AchievementMetric.GamePlayHours => counters.GamePlayHours,
+            AchievementMetric.UniqueGamesPlayed => counters.UniqueGamesPlayed,
+            AchievementMetric.UniqueGamePlatforms => counters.UniqueGamePlatforms,
 
             _ => 0
         };
+    }
+
+    // [issue #115] Distinct games behind a platform or studio key, matched
+    // case-insensitively so a badge parameter does not have to reproduce the
+    // provider's capitalisation.
+    private static int LookupGameSetCount(Dictionary<string, HashSet<string>> dict, string key)
+    {
+        if (dict.TryGetValue(key, out var exact)) return exact.Count;
+        foreach (var kv in dict)
+        {
+            if (string.Equals(kv.Key, key, StringComparison.OrdinalIgnoreCase)) return kv.Value.Count;
+        }
+
+        return 0;
     }
 
     // Approximate Saudi-calendar Eid al-Fitr and Eid al-Adha start dates.

--- a/Jellyfin.Plugin.AchievementBadges/Services/AchievementDefinitions.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/AchievementDefinitions.cs
@@ -391,5 +391,22 @@ public static class AchievementDefinitions
         new() { Id = "book-audio-veteran",     Key = "book_audio_veteran",     Title = "Audio Veteran",        Description = "Listen to 100 hours of audiobooks.",          Icon = "podcasts",       Category = "Books", Rarity = "Rare",      Media = MediaType.Book,  Metric = AchievementMetric.AudiobookListeningHours,   TargetValue = 100 },
 
         new() { Id = "book-series-finisher",   Key = "book_series_finisher",   Title = "Series Finisher",      Description = "Finish 3 book series.",                       Icon = "menu_book",      Category = "Books", Rarity = "Uncommon",  Media = MediaType.Book,  Metric = AchievementMetric.UniqueBookSeriesCompleted, TargetValue = 3 },
+
+        // [issue #115] Games played through JellyEmu. Sessions, hours, distinct
+        // games and platforms; per-platform and per-studio badges are left to
+        // the custom badge builder, where the admin names the platform or the
+        // developer.
+        new() { Id = "game-first-boot",        Key = "game_first_boot",        Title = "First Boot",           Description = "Play your first game session.",               Icon = "sports_esports", Category = "Games", Rarity = "Common",    Media = MediaType.Game,  Metric = AchievementMetric.GamePlays,           TargetValue = 1 },
+        new() { Id = "game-arcade-regular",    Key = "game_arcade_regular",    Title = "Arcade Regular",       Description = "Play 25 game sessions.",                      Icon = "videogame_asset", Category = "Games", Rarity = "Uncommon", Media = MediaType.Game,  Metric = AchievementMetric.GamePlays,           TargetValue = 25 },
+        new() { Id = "game-arcade-rat",        Key = "game_arcade_rat",        Title = "Arcade Rat",           Description = "Play 100 game sessions.",                     Icon = "stadia_controller", Category = "Games", Rarity = "Rare",   Media = MediaType.Game,  Metric = AchievementMetric.GamePlays,           TargetValue = 100 },
+
+        new() { Id = "game-cartridge-collector", Key = "game_cartridge_collector", Title = "Cartridge Collector", Description = "Play 10 different games.",              Icon = "grid_view",      Category = "Games", Rarity = "Common",    Media = MediaType.Game,  Metric = AchievementMetric.UniqueGamesPlayed,   TargetValue = 10 },
+        new() { Id = "game-backlog",           Key = "game_backlog",           Title = "Backlog",              Description = "Play 50 different games.",                    Icon = "inventory_2",    Category = "Games", Rarity = "Rare",      Media = MediaType.Game,  Metric = AchievementMetric.UniqueGamesPlayed,   TargetValue = 50 },
+
+        new() { Id = "game-marathon",          Key = "game_marathon",          Title = "Marathon",             Description = "Play for 10 hours.",                          Icon = "timer",          Category = "Games", Rarity = "Uncommon",  Media = MediaType.Game,  Metric = AchievementMetric.GamePlayHours,       TargetValue = 10 },
+        new() { Id = "game-long-haul",         Key = "game_long_haul",         Title = "Long Haul",            Description = "Play for 100 hours.",                         Icon = "hourglass_full", Category = "Games", Rarity = "Epic",      Media = MediaType.Game,  Metric = AchievementMetric.GamePlayHours,       TargetValue = 100 },
+
+        new() { Id = "game-console-wars",      Key = "game_console_wars",      Title = "Console Wars",         Description = "Play games on 3 different platforms.",        Icon = "devices",        Category = "Games", Rarity = "Uncommon",  Media = MediaType.Game,  Metric = AchievementMetric.UniqueGamePlatforms, TargetValue = 3 },
+        new() { Id = "game-retro-sommelier",   Key = "game_retro_sommelier",   Title = "Retro Sommelier",      Description = "Play games on 8 different platforms.",        Icon = "memory",         Category = "Games", Rarity = "Rare",      Media = MediaType.Game,  Metric = AchievementMetric.UniqueGamePlatforms, TargetValue = 8 },
     };
 }

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionService.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionService.cs
@@ -103,59 +103,10 @@ public class PlaybackCompletionService
                 state.RecentlyCompletedItemIds[itemId] = playedAt;
             }
 
-            // v1.9.8 — Daily watch-rate cap. Tracks credited items per UTC
-            // day. Real users watching real content never hit this; it's
-            // pure defense in depth against the spam-click exploit class.
-            var cfg = Plugin.Instance?.Configuration;
-            var today = playedAt.UtcDateTime.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-            state.CreditedItemsByDate.TryGetValue(today, out var todayCount);
-            if (cfg?.EnableDailyCreditCap == true && cfg.DailyCreditCap > 0 && todayCount >= cfg.DailyCreditCap)
+            if (!ApplyRateGuards(state, context.UserId, playedAt, out message))
             {
-                message = $"Daily credit cap reached ({cfg.DailyCreditCap}/day). Try again tomorrow.";
-                // Log only the FIRST time per day we hit the cap; subsequent
-                // attempts in the same day stay silent to avoid spam.
-                if (todayCount == cfg.DailyCreditCap)
-                {
-                    _auditLog?.Log(context.UserId, string.Empty, "rate_cap_blocked",
-                        $"User hit daily credit cap of {cfg.DailyCreditCap} items on {today}.");
-                }
                 return false;
             }
-
-            // v1.9.8 — Suspicious-rate flag. Track timestamps of credits in a
-            // rolling 1h window; if the user crosses SuspiciousRatePerHour
-            // emit an audit-log entry (throttled to once per hour per user).
-            // Visibility only — does not block the credit.
-            state.RecentCreditTimestamps.RemoveAll(t => playedAt - t > TimeSpan.FromHours(1));
-            state.RecentCreditTimestamps.Add(playedAt);
-            if (state.RecentCreditTimestamps.Count > 256)
-            {
-                state.RecentCreditTimestamps.RemoveRange(0, state.RecentCreditTimestamps.Count - 256);
-            }
-            if (cfg?.EnableSuspiciousActivityFlag == true && cfg.SuspiciousRatePerHour > 0
-                && state.RecentCreditTimestamps.Count >= cfg.SuspiciousRatePerHour
-                && (state.LastSuspiciousFlagAt is null
-                    || playedAt - state.LastSuspiciousFlagAt.Value > TimeSpan.FromHours(1)))
-            {
-                _auditLog?.Log(context.UserId, string.Empty, "suspicious_rate",
-                    $"User credited {state.RecentCreditTimestamps.Count} items in the last hour (threshold {cfg.SuspiciousRatePerHour}).");
-                state.LastSuspiciousFlagAt = playedAt;
-            }
-
-            // Prune the date dictionary to last 30 days so it doesn't grow
-            // unbounded over months.
-            if (state.CreditedItemsByDate.Count > 60)
-            {
-                var cutoff = playedAt.UtcDateTime.AddDays(-30);
-                var stale = state.CreditedItemsByDate
-                    .Where(kvp => !System.DateTime.TryParseExact(kvp.Key, "yyyy-MM-dd",
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        System.Globalization.DateTimeStyles.AssumeUniversal, out var d) || d < cutoff)
-                    .Select(kvp => kvp.Key)
-                    .ToList();
-                foreach (var key in stale) state.CreditedItemsByDate.Remove(key);
-            }
-            state.CreditedItemsByDate[today] = todayCount + 1;
 
             state.TotalCompletedItems++;
 
@@ -289,6 +240,130 @@ public class PlaybackCompletionService
         {
             return CloneState(GetOrCreateState(userId));
         }
+    }
+
+    /// <summary>
+    /// The per-user rate guards every credit passes through, whatever the
+    /// media: the daily cap (blocking), the suspicious-rate audit flag
+    /// (visibility only) and the 30-day prune of the per-day counts. Extracted
+    /// so a game session (issue #115) gets the same defence without the
+    /// completion gate and the per-item dedupe, which do not fit a session.
+    /// Must be called under <c>_lock</c>.
+    /// </summary>
+    private bool ApplyRateGuards(UserPlaybackState state, string userId, DateTimeOffset playedAt, out string message)
+    {
+        // v1.9.8: daily watch-rate cap. Tracks credited items per UTC
+        // day. Real users watching real content never hit this; it is
+        // pure defense in depth against the spam-click exploit class.
+        var cfg = Plugin.Instance?.Configuration;
+        var today = playedAt.UtcDateTime.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+        state.CreditedItemsByDate.TryGetValue(today, out var todayCount);
+        if (cfg?.EnableDailyCreditCap == true && cfg.DailyCreditCap > 0 && todayCount >= cfg.DailyCreditCap)
+        {
+            message = $"Daily credit cap reached ({cfg.DailyCreditCap}/day). Try again tomorrow.";
+            // Log only the FIRST time per day the cap is hit; subsequent
+            // attempts in the same day stay silent to avoid spam.
+            if (todayCount == cfg.DailyCreditCap)
+            {
+                _auditLog?.Log(userId, string.Empty, "rate_cap_blocked",
+                    $"User hit daily credit cap of {cfg.DailyCreditCap} items on {today}.");
+            }
+            return false;
+        }
+
+        // v1.9.8: suspicious-rate flag. Track timestamps of credits in a
+        // rolling 1h window; if the user crosses SuspiciousRatePerHour
+        // emit an audit-log entry (throttled to once per hour per user).
+        // Visibility only; it does not block the credit.
+        state.RecentCreditTimestamps.RemoveAll(t => playedAt - t > TimeSpan.FromHours(1));
+        state.RecentCreditTimestamps.Add(playedAt);
+        if (state.RecentCreditTimestamps.Count > 256)
+        {
+            state.RecentCreditTimestamps.RemoveRange(0, state.RecentCreditTimestamps.Count - 256);
+        }
+        if (cfg?.EnableSuspiciousActivityFlag == true && cfg.SuspiciousRatePerHour > 0
+            && state.RecentCreditTimestamps.Count >= cfg.SuspiciousRatePerHour
+            && (state.LastSuspiciousFlagAt is null
+                || playedAt - state.LastSuspiciousFlagAt.Value > TimeSpan.FromHours(1)))
+        {
+            _auditLog?.Log(userId, string.Empty, "suspicious_rate",
+                $"User credited {state.RecentCreditTimestamps.Count} items in the last hour (threshold {cfg.SuspiciousRatePerHour}).");
+            state.LastSuspiciousFlagAt = playedAt;
+        }
+
+        // Prune the date dictionary to last 30 days so it doesn't grow
+        // unbounded over months.
+        if (state.CreditedItemsByDate.Count > 60)
+        {
+            var cutoff = playedAt.UtcDateTime.AddDays(-30);
+            var stale = state.CreditedItemsByDate
+                .Where(kvp => !System.DateTime.TryParseExact(kvp.Key, "yyyy-MM-dd",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeUniversal, out var d) || d < cutoff)
+                .Select(kvp => kvp.Key)
+                .ToList();
+            foreach (var key in stale) state.CreditedItemsByDate.Remove(key);
+        }
+        state.CreditedItemsByDate[today] = todayCount + 1;
+
+        message = string.Empty;
+        return true;
+    }
+
+    /// <summary>
+    /// [issue #115] Credit one game session reported by JellyEmu. A session
+    /// is not a completion: there is no 80% of a game, and the same game
+    /// played twice in an evening is two sessions, so the completion gate and
+    /// the six-hour per-item dedupe of <see cref="RecordCompletion(PlaybackContext, double, out string)"/>
+    /// do not apply. The rate guards do. The seconds are already clamped by
+    /// the tracker; zero means the session was too short to count.
+    /// </summary>
+    public bool RecordGameSession(PlaybackContext context, out string message)
+    {
+        if (string.IsNullOrWhiteSpace(context.UserId))
+        {
+            message = "User ID is required.";
+            return false;
+        }
+
+        if (!context.IsGame)
+        {
+            message = "Not a game session.";
+            return false;
+        }
+
+        if (context.GamePlaySeconds <= 0)
+        {
+            message = "Session too short to count.";
+            return false;
+        }
+
+        var playedAt = context.PlayedAt ?? DateTimeOffset.Now;
+        context.PlayedAt = playedAt;
+
+        lock (_lock)
+        {
+            var state = GetOrCreateState(context.UserId);
+            CleanupOldEntries(state, playedAt);
+
+            if (!ApplyRateGuards(state, context.UserId, playedAt, out message))
+            {
+                return false;
+            }
+
+            state.LastCompletionAt = playedAt;
+            Save();
+        }
+
+        _achievementBadgeService.RecordPlayback(context);
+
+        if (Guid.TryParse(context.UserId, out var playerGuid))
+        {
+            FriendsService.InvalidateLastWatched(playerGuid);
+        }
+
+        message = "Game session recorded.";
+        return true;
     }
 
     private UserPlaybackState GetOrCreateState(string userId)

--- a/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
+++ b/Jellyfin.Plugin.AchievementBadges/Services/PlaybackCompletionTracker.cs
@@ -455,6 +455,18 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
                 return;
             }
 
+            // [issue #115] A game played through JellyEmu is a Book with no
+            // runtime whose playback position is wall-clock elapsed time.
+            // Two checks below are built for video and would drop it: the
+            // "runtime ticks unavailable" gate, and the accumulator's seek
+            // filter, which reads every 30-second progress ping as a jump.
+            // Games leave the video path here and are measured as sessions.
+            if (isBook && GameSession.IsGame(GetEffectiveTags(item, inheritFromParent: false), item.ProviderIds))
+            {
+                RecordGameSession(e, source, userId, item, itemId);
+                return;
+            }
+
             var runTimeTicks = item.RunTimeTicks ?? 0;
 
             // v1.9.8 — Reject items shorter than 60s. Projectionist prerolls,
@@ -609,6 +621,67 @@ public class PlaybackCompletionTracker : IHostedService, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "[AchievementBadges] Failed to process playback completion from {Source}.", source);
+        }
+    }
+
+    /// <summary>
+    /// [issue #115] Credit one game session. The length is the smaller of what
+    /// JellyEmu reported (its playback position is elapsed time) and what this
+    /// tracker saw on its own clock since the first progress ping, bounded by
+    /// the configured floor and cap. The session state is removed either way
+    /// so it never leaks into the next item.
+    /// </summary>
+    private void RecordGameSession(PlaybackProgressEventArgs e, string source, string userId, BaseItem item, string itemId)
+    {
+        var reportedSeconds = (e.PlaybackPositionTicks ?? 0) / TimeSpan.TicksPerSecond;
+        long wallClockSeconds = 0;
+        var sessionId = e.Session?.Id;
+        if (!string.IsNullOrWhiteSpace(sessionId) && _sessions.TryRemove(sessionId, out var session))
+        {
+            wallClockSeconds = (long)(DateTimeOffset.UtcNow - session.StartedAt).TotalSeconds;
+        }
+
+        var cfg = Plugin.Instance?.Configuration;
+        var minSeconds = cfg?.MinGameSessionSeconds ?? 60;
+        var maxSeconds = (cfg?.MaxGameSessionMinutes ?? 360) * 60L;
+        var seconds = GameSession.ClampSeconds(reportedSeconds, wallClockSeconds, minSeconds, maxSeconds);
+        if (seconds <= 0)
+        {
+            _logger.LogDebug(
+                "[AchievementBadges] {Source} game session for user {UserId} item {ItemId}: reported {Reported}s, seen {Seen}s; below the {Floor}s floor, not counted.",
+                source, userId, itemId, reportedSeconds, wallClockSeconds, minSeconds);
+            return;
+        }
+
+        var tags = GetEffectiveTags(item, inheritFromParent: false);
+        var context = new PlaybackContext
+        {
+            UserId = userId,
+            ItemId = itemId,
+            OriginDeviceId = !string.IsNullOrWhiteSpace(e.DeviceId) ? e.DeviceId : e.Session?.DeviceId,
+            IsGame = true,
+            GamePlatform = GameSession.Platform(tags),
+            GamePlaySeconds = seconds,
+            LibraryName = ResolveLibraryName(item),
+            PlayedAt = DateTimeOffset.Now,
+            ProductionYear = item.ProductionYear,
+            Genres = GetEffectiveGenres(item, inheritFromParent: false),
+            Tags = tags,
+            Studios = item.Studios,
+        };
+
+        var success = _playbackCompletionService.RecordGameSession(context, out var message);
+        if (success)
+        {
+            _logger.LogInformation(
+                "[AchievementBadges] Recorded game session from {Source} user={UserId} item={ItemId} platform={Platform} seconds={Seconds}",
+                source, userId, itemId, context.GamePlatform, seconds);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "[AchievementBadges] Skipped game session from {Source} user={UserId} item={ItemId} reason={Reason}",
+                source, userId, itemId, message);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ Big thanks to **[@camarigor](https://github.com/camarigor)** for the friend prof
 - **8 book badges (v2.1.0)** — books completed, audiobook listening hours, and series completed. Audiobook plays route per the **audiobook-counting policy** (Books-only default / Music-only / Both).
 - **Improved anime detection (v2.1.0, #25)** — matches **Genres *and* Tags** on the item *and its parent Series*, with admin-configurable libraries / genres / tags.
 - **Admin-authored custom badges (v2.1.0)** — compound AND/OR criteria across any metric; see [Custom badges](#-custom-badges).
-- **Targeted badges (v2.4.0, #107)** — point a badge at one specific series, season, collection, playlist, album or item; see [Targeted badges](#targeted-badges).
+- **Targeted badges (v2.4.0, #107)**: point a badge at one specific series, season, collection, playlist, album or item; see [Targeted badges](#targeted-badges).
+- **Game achievements (v2.4.0, #115)**: sessions, hours, distinct games and platforms for games played through JellyEmu, plus custom badges per platform, per developer and per game; see [Game achievements](#game-achievements-jellyemu).
 - **6 rarity tiers** — Common, Uncommon, Rare, Epic, Legendary, Mythic
 - **Hidden/secret badges** displayed as `???` until unlocked
 - **Library completion milestones** that auto-scale to any library structure
@@ -438,6 +439,20 @@ Targeted badges are evaluated against your existing history, so a badge you auth
   }
 }
 ```
+
+### Game achievements (JellyEmu)
+
+> Added in **v2.4.0**, from [#115](https://github.com/ZL154/AchievementBadges_for_Jellyfin/issues/115).
+
+Games played through [JellyEmu](https://github.com/Jellyfin-PG/JellyEmu) earn achievements with no setup on the JellyEmu side. JellyEmu reports every game session to Jellyfin as a playback session and tags each game with `JellyEmu`, `Game` and its platform; this plugin reads those and measures each session as the smaller of what the emulator reported and what the plugin saw on its own clock, with a floor (`MinGameSessionSeconds`, default 60) so a misclick is not a play and a cap (`MaxGameSessionMinutes`, default 360) so a tab left open is not a night of play.
+
+Built in, under the **Games** category: session ladders (1, 25, 100), distinct games (10, 50), hours (10, 100) and platforms (3, 8). For custom badges, the builder offers:
+
+- `GamePlatformGames` with the platform tag as parameter (`SNES`, `SegaGenesis`, `PlayStation`; the spelling is JellyEmu's, matched without regard to case): "play 10 Sega Genesis games".
+- `GameStudioGames` with the developer or publisher as parameter: "play 5 games by Capcom".
+- `GameHours` with a specific game as target, chosen in the picker like any other targeted badge: "30 hours in this game".
+
+Two limits worth knowing: play time counts from the moment this version is installed, because games carry no played flag to rebuild history from; and nothing here reads RetroAchievements, whose unlocks cannot happen in JellyEmu's browser emulator (see the discussion on #115).
 
 ### Template — simple badge
 

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -14,6 +14,16 @@ Requested by **@unknownTGG** in #107.
 - **Moves on manual marking, not only on playback.** The trigger is Jellyfin's own played flag, so marking a season watched by hand advances the badge. That is how an old arc actually gets completed.
 - **Bounded cost.** Only the targets that enabled badges actually reference are ever computed. `MaxTargetedBadgeTargets` (default 50) caps how many, and targets past the cap are named in the log rather than dropped silently.
 
+## Added - game achievements
+
+Requested by **@TsunamicFlame** in #115.
+
+- **Games played through JellyEmu now earn achievements.** JellyEmu already reported each game session to Jellyfin as a playback session; this plugin dropped them because games are `Book` items with no runtime and two of its checks were built for video. Sessions are now measured on their own terms: the smaller of what the emulator reported and what the plugin saw on its own clock, with a floor for misclicks and a cap for a tab left open, both configurable.
+- **Nine built-in badges** under a new Games category: sessions, distinct games, hours and platforms.
+- **Three custom-badge metrics**: distinct games on a platform, distinct games from a developer or publisher, and hours in one specific game through the target picker.
+- **Same abuse guards as everything else** (daily credit cap, suspicious-rate flag), without the completion gate and the six-hour per-item dedupe, which do not fit a session: the same game twice in an evening is two sessions.
+- **Not included, on purpose**: RetroAchievements sync. Nothing played in JellyEmu's browser emulator can unlock one, so it would only reward play that happens elsewhere.
+
 ## Changed
 
 - The `library-completion/recompute` endpoint now also recomputes targeted progress and returns it, so a broken or unwanted scan does not leave targeted badges unreachable.


### PR DESCRIPTION
## Summary

Closes #115.

Games played through JellyEmu now earn achievements. JellyEmu already reports each game session to Jellyfin as a playback session (`OnPlaybackStart`, a progress ping every 30 seconds whose position is the elapsed time, `OnPlaybackStopped`). This plugin dropped every one of them: games are `Book` items with no runtime, so the stop handler returned at the runtime gate, and even past that gate the accumulator's 15 second seek filter would have read each 30 second ping as a jump. A Book never reaches 80% of a runtime it does not have, and the six hour per-item dedupe would refuse the same game played twice in an evening, so a game session got its own path instead of a patch on the video one.

## What I changed

- **Detection** (`Helpers/GameSession.cs`): an item is a game when it carries JellyEmu's `JellyEmu` or `Game` tag, or an IGDB, RAWG or RetroAchievements provider id. The platform is the first tag that matches JellyEmu's platform list, spelled JellyEmu's way.
- **Measurement** (`PlaybackCompletionTracker`): a game leaves the video path before the runtime gate and the seek filter. Its session length is the smaller of the position the client reported and the wall clock time the tracker saw since the first ping, with a floor (`MinGameSessionSeconds`, default 60) and a cap (`MaxGameSessionMinutes`, default 360), both configurable.
- **Crediting** (`PlaybackCompletionService.RecordGameSession`): the daily cap and the suspicious-rate flag apply; they moved out of `RecordCompletion` into a shared `ApplyRateGuards`. The 80% gate and the six hour dedupe do not apply. The movie path is unchanged and a test pins that it still dedupes.
- **Counters and metrics**: sessions, seconds, distinct games, seconds per game, games per platform and games per studio. Seven `AchievementMetric` values (`GamePlays`, `GamePlayHours`, `UniqueGamesPlayed`, `UniqueGamePlatforms`, `GamePlatformGames`, `GameStudioGames`, `GameHours`) and `MediaType.Game`, all appended so no stored ordinal moves.
- **Nine built-in badges** under a Games category: sessions (1, 25, 100), distinct games (10, 50), hours (10, 100), platforms (3, 8).
- **Config page**: the game metrics in the custom badge builder, Game in the media selector, the parameter field reworded for a platform tag or a studio name, and the picker behind `GameHours` filtered by `Tags=JellyEmu` so it lists games rather than books.
- **Counter floor**: the two per key sets (games per platform, per studio) are a shape `CounterFloor` had never seen, so a watch history scan would have emptied them while the totals next to them survived. The floor now unions those sets per key, with a test that fails on the old code.
- **Docs**: README section with the limits stated, and a section in the v2.4.0 release note. I also fixed a stray dash in the targeted badges line while I was there.

## What is not in this PR, on purpose

- **RetroAchievements sync.** I read the JellyEmu and EmulatorJS code before designing this: the embedded EmulatorJS has no RetroAchievements runtime (EmulatorJS #589 open since 2023, #1016 closed as "will likely never happen"), and grimmdev confirmed on JellyEmu #177 that nothing can be unlocked from the web player. Syncing RA would only reward play that happens outside Jellyfin. Details in my comment on #115.
- **In-game milestones** ("beat world 1"). Same reason: there is no signal for them in the browser.
- **Backfill.** Games carry no played flag or play count in Jellyfin, so there is no history to rebuild from. Play time counts from the moment this build is installed, and a watch history scan neither adds nor removes game progress.
- **Translations.** The category and badge titles fall back to English like every other built-in badge (the config page does not load translations).

## Verification

| Check | Result |
|---|---|
| `dotnet test` (net9.0) | 251 passed, 0 failed (17 new: 7 `GameSessionTests`, 4 `GameAchievementTests`, 5 `GameSessionPipelineTests`, 1 in `DataResilienceTests`) |
| Control | the counter floor test fails with the old `CounterFloor` and passes with the new one |
| `dotnet build -c Release` | 0 warnings, 0 errors, with `TreatWarningsAsErrors` on |
| Config page JS | `node --check` on the embedded script passes |
| Enum ordinals | `ArtistCompletionPercent` 70, `ContainerCompletionPercent` 71, `ItemPlayCount` 72 pinned; the new values are 73 to 79, and `MediaType.Game` is 6 |

I do not run JellyEmu, so the tracker path is verified by unit tests against the event shape I read in JellyEmu's `JellyEmuSessionService` (position ticks equal to elapsed seconds, a ping every 30 seconds), not by a live session. @TsunamicFlame, if you can install this build and play something for a couple of minutes, `First Boot` should unlock at the stop event and the server log should show a line like this:

```
[AchievementBadges] Recorded game session from stopped user=... item=... platform=SNES seconds=142
```

I would take that log excerpt as the acceptance test, and I am happy to adjust the floor, the cap or the detection if a real session looks different from what I read in the code.
