### PR TITLE
fix: Jellyfin 12 support in the web client (avatar menu entry, authorization header, dashboard layout)

### DIFF
--- a/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
@@ -183,6 +183,41 @@ public class Jellyfin12ShellTests
     }
 
     [Fact]
+    public void TheAdminProfileCardKeepsItsSubtitleAndUsesTheWholeHeroForTheShowcase()
+    {
+        // Two things seen on a live server. The subtitle went back to
+        // "Loading..." after the summary had written "Completion: 42.7%",
+        // because the translation applier rewrites every [data-i18n]
+        // element and the summary can land first. And the showcase sat in
+        // the hero's left column, next to three wide buttons, so a 1400px
+        // card showed two columns of badges.
+        var html = ReadEmbedded("Pages.index.html");
+
+        var completion = html.IndexOf("tr('achievements.completion', 'Completion')", StringComparison.Ordinal);
+        var detached = html.IndexOf("profileSubtitle.removeAttribute('data-i18n');", completion, StringComparison.Ordinal);
+        Assert.True(completion >= 0 && detached > completion && detached - completion < 600);
+        Assert.Equal(3, CountOf(html, "profileSubtitle.removeAttribute('data-i18n');"));
+
+        var actions = html.IndexOf("<div class=\"abHeroActions\">", StringComparison.Ordinal);
+        var showcase = html.IndexOf("<div id=\"abShowcaseWrap\"", StringComparison.Ordinal);
+        Assert.True(actions >= 0 && showcase > actions);
+        Assert.Contains(".abShowcaseWrap{\nmargin-top:1.1em;\nflex-basis:100%;", html, StringComparison.Ordinal);
+        Assert.Contains("grid-template-columns:repeat(auto-fill,minmax(300px,1fr));", html, StringComparison.Ordinal);
+    }
+
+    private static int CountOf(string text, string needle)
+    {
+        var count = 0;
+        var index = text.IndexOf(needle, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = text.IndexOf(needle, index + needle.Length, StringComparison.Ordinal);
+        }
+        return count;
+    }
+
+    [Fact]
     public void TheLegacyDrawerInjectionStays()
     {
         // Jellyfin 12 still offers desktop-legacy, mobile-legacy and tv

--- a/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
@@ -161,6 +161,27 @@ public class Jellyfin12ShellTests
         Assert.True(watchdog >= 0 && reapplied > watchdog);
     }
 
+    [Theory]
+    [InlineData("shell.js")]
+    [InlineData("navinject.js")]
+    [InlineData("profileinject.js")]
+    [InlineData("profile-card.html")]
+    [InlineData("profile-card-blades.html")]
+    [InlineData("profile-card-metro.html")]
+    [InlineData("configPage.html")]
+    [InlineData("standalone.js")]
+    [InlineData("enhance.js")]
+    [InlineData("Pages.index.html")]
+    public void NoAssetLinksToTheDeprecatedBangRoutes(string asset)
+    {
+        // jellyfin-web 12 still redirects #!/ routes, with a console
+        // warning that the format will stop working; the routes have been
+        // #/ since 10.9. sidebar.js keeps both spellings on purpose in its
+        // login route checks, so it is not in this list.
+        var text = ReadEmbedded(asset);
+        Assert.DoesNotContain("#!/", text, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void TheLegacyDrawerInjectionStays()
     {

--- a/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.AchievementBadges.Tests;
+
+/// <summary>
+/// Jellyfin 12 ships a new default layout ("modern") that keeps the old
+/// .mainDrawer and .skinHeader in the DOM only so legacy scripts do not
+/// throw; both are hidden. The plugin's sidebar entry and equipped-badge
+/// strip were injected into exactly those two elements, so on 12 they
+/// existed and nobody could see them, and the only way to the achievements
+/// page was gone. These pin the two new hooks: the avatar menu (an MUI Menu
+/// with a stable id that stays mounted while closed) and the MUI toolbar.
+/// </summary>
+public class Jellyfin12ShellTests
+{
+    private static string ReadEmbedded(string suffix)
+    {
+        var assembly = typeof(Plugin).Assembly;
+        var name = assembly.GetManifestResourceNames().Single(n => n.EndsWith(suffix, StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(name)!;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    [Fact]
+    public void TheAvatarMenuGetsAnAchievementsEntryBelowProfile()
+    {
+        var js = ReadEmbedded("sidebar.js");
+
+        Assert.Contains("getElementById('app-user-menu')", js, StringComparison.Ordinal);
+        Assert.Contains("a[href*=\"/userprofile\"]", js, StringComparison.Ordinal);
+        Assert.Contains("item.setAttribute('href','#/achievements')", js, StringComparison.Ordinal);
+
+        // Placement: right after the Profile item, never appended blindly
+        // while Profile exists.
+        var inject = js.IndexOf("function injectUserMenu()", StringComparison.Ordinal);
+        var afterProfile = js.IndexOf("list.insertBefore(item, profile.nextSibling)", inject, StringComparison.Ordinal);
+        Assert.True(inject >= 0);
+        Assert.True(afterProfile > inject);
+
+        // The clone has no React handler, so the script closes the menu itself.
+        Assert.Contains("#app-user-menu .MuiBackdrop-root", js, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheEntryIsInjectedOnEveryPassAndTranslated()
+    {
+        var js = ReadEmbedded("sidebar.js");
+
+        var tryInject = js.IndexOf("function tryInject()", StringComparison.Ordinal);
+        var header = js.IndexOf("injectHeader();", tryInject, StringComparison.Ordinal);
+        var userMenu = js.IndexOf("injectUserMenu();", header, StringComparison.Ordinal);
+        Assert.True(tryInject >= 0);
+        Assert.True(header > tryInject);
+        Assert.True(userMenu > header);
+
+        var translate = js.IndexOf("function applyTranslations()", StringComparison.Ordinal);
+        var entryText = js.IndexOf("getElementById(USER_MENU_ID)", translate, StringComparison.Ordinal);
+        Assert.True(entryText > translate);
+    }
+
+    [Fact]
+    public void TheEquippedStripFallsBackToTheMuiToolbar()
+    {
+        var js = ReadEmbedded("sidebar.js");
+
+        var injectHeader = js.IndexOf("function injectHeader()", StringComparison.Ordinal);
+        var legacy = js.IndexOf("querySelector('.headerRight')", injectHeader, StringComparison.Ordinal);
+        var modern = js.IndexOf("button[aria-controls=\"app-user-menu\"]", legacy, StringComparison.Ordinal);
+        Assert.True(injectHeader >= 0);
+        Assert.True(legacy > injectHeader);
+        Assert.True(modern > legacy);
+    }
+
+    [Fact]
+    public void TheLegacyDrawerInjectionStays()
+    {
+        // Jellyfin 12 still offers desktop-legacy, mobile-legacy and tv
+        // layouts, all on the old drawer.
+        var js = ReadEmbedded("sidebar.js");
+        Assert.Contains("function injectSidebar()", js, StringComparison.Ordinal);
+        Assert.Contains("querySelectorAll('.navMenuOption')", js, StringComparison.Ordinal);
+    }
+}

--- a/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
@@ -110,6 +110,58 @@ public class Jellyfin12ShellTests
     }
 
     [Fact]
+    public void TheRevampAdminPageStaysInsideTheDashboardContentArea()
+    {
+        // The Revamp admin page takes the viewport with position: fixed.
+        // The MUI dashboard keeps a docked 240px drawer and a fixed app bar
+        // on layers above it, so the left 240px and the top 48px of the page
+        // were hidden. The bootstrap measures both and the stylesheet
+        // insets the page by them.
+        var html = ReadEmbedded("Pages.index.html");
+        var css = ReadEmbedded("styles-revamp.css");
+
+        Assert.Contains("function fitDashboardShell()", html, StringComparison.Ordinal);
+        Assert.Contains("querySelector('.MuiDrawer-docked')", html, StringComparison.Ordinal);
+        Assert.Contains("querySelector('.dashboard-appBar')", html, StringComparison.Ordinal);
+        Assert.Contains("setProperty('--ab-dash-left'", html, StringComparison.Ordinal);
+        Assert.Contains("setProperty('--ab-dash-top'", html, StringComparison.Ordinal);
+        // Re-measured after layout settles, not only on the resize event.
+        Assert.Contains("new ResizeObserver(function () { measureDashboardShell(); })", html, StringComparison.Ordinal);
+
+        var apply = html.IndexOf("function applyBodyClassAndWatch()", StringComparison.Ordinal);
+        var fit = html.IndexOf("fitDashboardShell();", apply, StringComparison.Ordinal);
+        var remove = html.IndexOf("function removeBodyClassAndUnwatch()", StringComparison.Ordinal);
+        var release = html.IndexOf("releaseDashboardShell();", remove, StringComparison.Ordinal);
+        Assert.True(apply >= 0 && fit > apply);
+        Assert.True(remove >= 0 && release > remove);
+
+        Assert.Contains("body.ab-revamp-fullwidth.ab-dash-shell #AchievementBadgesPage", css, StringComparison.Ordinal);
+        Assert.Contains("inset: var(--ab-dash-top, 48px) 0 0 var(--ab-dash-left, 240px) !important;", css, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheTabIsNamedAfterThePageWhileTheRouteIsOurs()
+    {
+        // The SPA renders its "Page not found" route under the overlay and
+        // names the tab after it.
+        var js = ReadEmbedded("standalone.js");
+
+        Assert.Contains("function applyDocumentTitle()", js, StringComparison.Ordinal);
+        Assert.Contains("if (document.title !== wanted) document.title = wanted;", js, StringComparison.Ordinal);
+
+        var mount = js.IndexOf("function mountRoute(host)", StringComparison.Ordinal);
+        var applied = js.IndexOf("applyDocumentTitle();", mount, StringComparison.Ordinal);
+        var watched = js.IndexOf("watchDocumentTitle();", mount, StringComparison.Ordinal);
+        Assert.True(mount >= 0 && applied > mount && watched > mount);
+
+        // The 1.5s watchdog re-applies it, so a late title write by the SPA
+        // never sticks.
+        var watchdog = js.IndexOf("setInterval(function () {", js.IndexOf("function unmountRoute()", StringComparison.Ordinal), StringComparison.Ordinal);
+        var reapplied = js.IndexOf("applyDocumentTitle();", watchdog, StringComparison.Ordinal);
+        Assert.True(watchdog >= 0 && reapplied > watchdog);
+    }
+
+    [Fact]
     public void TheLegacyDrawerInjectionStays()
     {
         // Jellyfin 12 still offers desktop-legacy, mobile-legacy and tv

--- a/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
+++ b/Jellyfin.Plugin.AchievementBadges.Tests/Jellyfin12ShellTests.cs
@@ -75,6 +75,40 @@ public class Jellyfin12ShellTests
         Assert.True(modern > legacy);
     }
 
+    [Theory]
+    [InlineData("sidebar.js")]
+    [InlineData("standalone.js")]
+    [InlineData("enhance.js")]
+    [InlineData("Pages.index.html")]
+    [InlineData("configPage.html")]
+    public void EveryAuthenticatedCallSendsTheCurrentAuthorizationHeader(string asset)
+    {
+        // Jellyfin 12.0 runs a migration (DisableLegacyAuthorization) that
+        // refuses X-Emby-Token, X-MediaBrowser-Token and api_key in the
+        // query. Every plugin call that carried only the legacy header
+        // answered 401 on 12: badges, preferences, friends, the admin
+        // catalog. The current form is the only one 12 accepts, and 10.11
+        // accepts both, so both are sent.
+        var text = ReadEmbedded(asset);
+
+        Assert.Contains("MediaBrowser Token=\"'", text, StringComparison.Ordinal);
+        // The legacy header never travels alone any more: each place that
+        // sets it also sets Authorization within the same block.
+        var sites = 0;
+        foreach (var needle in new[] { "['X-Emby-Token'] =", "['X-Emby-Token']=" })
+        {
+            var index = text.IndexOf(needle, StringComparison.Ordinal);
+            while (index >= 0)
+            {
+                sites++;
+                var windowStart = Math.Max(0, index - 400);
+                Assert.Contains("Authorization", text.Substring(windowStart, index - windowStart), StringComparison.Ordinal);
+                index = text.IndexOf(needle, index + needle.Length, StringComparison.Ordinal);
+            }
+        }
+        Assert.True(sites > 0, "the asset sets no token header at all");
+    }
+
     [Fact]
     public void TheLegacyDrawerInjectionStays()
     {

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
@@ -523,7 +523,11 @@
                             }
                         }
                         var token = ApiClient._serverInfo && ApiClient._serverInfo.AccessToken;
-                        if (token) headers['X-Emby-Token'] = token;
+                        if (!token && typeof ApiClient.accessToken === 'function') {
+                            try { token = ApiClient.accessToken(); } catch (e) {}
+                        }
+                        // [Jellyfin 12] legacy token headers are refused; send the current form too.
+                        if (token) { headers['Authorization'] = 'MediaBrowser Token="' + token + '"'; headers['X-Emby-Token'] = token; }
                     }
                     return headers;
                 },

--- a/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AchievementBadges/Configuration/configPage.html
@@ -643,7 +643,7 @@
                         alert('Pick a user first.');
                         return;
                     }
-                    window.location.href = this.getWebRoot() + 'index.html#!/configurationpage?name=achievementbadges&userId=' + encodeURIComponent(userId);
+                    window.location.href = this.getWebRoot() + 'index.html#/configurationpage?name=achievementbadges&userId=' + encodeURIComponent(userId);
                 },
 
                 load: function () {

--- a/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/enhance.js
@@ -108,12 +108,24 @@
         return (api && typeof api.getUrl === 'function') ? api.getUrl(c) : '/' + c;
     }
 
+    // [Jellyfin 12] Legacy authorization (X-Emby-Token, X-MediaBrowser-Token,
+    // api_key in the query) is switched off by a 12.0 migration, so every
+    // authenticated call answered 401. Send the current form; the legacy
+    // header stays because 10.11 accepts either.
+    function setTokenHeaders(h, t) {
+        h['Authorization'] = 'MediaBrowser Token="' + t + '"';
+        h['X-Emby-Token'] = t;
+        return h;
+    }
+
     function authHeaders() {
         var h = { 'Content-Type': 'application/json' };
         var api = getApi(); if (!api) return h;
         try {
-            if (typeof api.accessToken === 'function') { var t = api.accessToken(); if (t) h['X-Emby-Token'] = t; }
-            else if (api._serverInfo && api._serverInfo.AccessToken) h['X-Emby-Token'] = api._serverInfo.AccessToken;
+            var t = null;
+            if (typeof api.accessToken === 'function') t = api.accessToken();
+            if (!t && api._serverInfo && api._serverInfo.AccessToken) t = api._serverInfo.AccessToken;
+            if (t) setTokenHeaders(h, t);
         } catch (e) { }
         return h;
     }

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -2424,7 +2424,8 @@ font-size:0.88em;
                 try {
                     if (apiClient && typeof apiClient.accessToken === 'function') {
                         var t = apiClient.accessToken();
-                        if (t) h['X-Emby-Token'] = t;
+                        // [Jellyfin 12] legacy token headers are refused; send the current form too.
+                        if (t) { h['Authorization'] = 'MediaBrowser Token="' + t + '"'; h['X-Emby-Token'] = t; }
                     }
                 } catch (e) {}
                 return h;
@@ -2559,7 +2560,14 @@ font-size:0.88em;
                 }
             }
             var token = apiClient._serverInfo && apiClient._serverInfo.AccessToken;
+            if (!token && typeof apiClient.accessToken === 'function') {
+                try { token = apiClient.accessToken(); } catch (e) {}
+            }
             if (token) {
+                // [Jellyfin 12] Legacy authorization is off after the 12.0
+                // migration, so X-Emby-Token alone answers 401. Send the
+                // current form; 10.11 accepts either.
+                headers['Authorization'] = 'MediaBrowser Token="' + token + '"';
                 headers['X-Emby-Token'] = token;
             }
         }

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -1358,8 +1358,56 @@ font-size:0.88em;
     var bgSavedBody = null, bgSavedHtml = null;
     var PAGE_BG = 'oklch(11% 0.008 260)';
 
+    /* [Jellyfin 12] The dashboard shell is MUI: a docked drawer (240px, a
+       fixed layer above this page) on medium screens and up, and a fixed
+       app bar on every size. Taking the whole viewport put the leftmost
+       240px of this page under the drawer and its first 48px under the
+       bar. Measure both, hand them to the stylesheet as variables, and
+       keep them fresh on resize; the stylesheet keeps MUI's defaults as
+       fallbacks. Nothing here runs on the legacy dashboard, which has no
+       .dashboard-appBar. */
+    var _abDashResize = null;
+    var _abDashObserver = null;
+    function measureDashboardShell() {
+        var root = document.documentElement;
+        var docked = document.querySelector('.MuiDrawer-docked');
+        var bar = document.querySelector('.dashboard-appBar');
+        var left = docked ? Math.round(docked.getBoundingClientRect().width) : 0;
+        var top = bar ? Math.round(bar.getBoundingClientRect().height) : 0;
+        root.style.setProperty('--ab-dash-left', left + 'px');
+        root.style.setProperty('--ab-dash-top', top + 'px');
+    }
+    function fitDashboardShell() {
+        if (!document.querySelector('.dashboard-appBar')) return;
+        document.body.classList.add('ab-dash-shell');
+        measureDashboardShell();
+        if (!_abDashResize) {
+            /* The drawer switches between docked and overlay at MUI's md
+               breakpoint through a React re-render, which lands after the
+               resize event. A ResizeObserver on body fires once layout has
+               settled, so the measurement sees the drawer that is really
+               there; the resize listener stays for browsers without it. */
+            _abDashResize = function () { setTimeout(measureDashboardShell, 150); };
+            window.addEventListener('resize', _abDashResize);
+            try {
+                if (window.ResizeObserver) {
+                    _abDashObserver = new ResizeObserver(function () { measureDashboardShell(); });
+                    _abDashObserver.observe(document.body);
+                }
+            } catch (_) {}
+        }
+    }
+    function releaseDashboardShell() {
+        document.body.classList.remove('ab-dash-shell');
+        document.documentElement.style.removeProperty('--ab-dash-left');
+        document.documentElement.style.removeProperty('--ab-dash-top');
+        if (_abDashResize) { window.removeEventListener('resize', _abDashResize); _abDashResize = null; }
+        if (_abDashObserver) { try { _abDashObserver.disconnect(); } catch (_) {} _abDashObserver = null; }
+    }
+
     function applyBodyClassAndWatch() {
         if (document.body) document.body.classList.add('ab-revamp-fullwidth');
+        try { fitDashboardShell(); } catch (_) {}
 
         if (bgSavedBody === null && document.body) {
             bgSavedBody = document.body.style.background || '';
@@ -1413,6 +1461,7 @@ font-size:0.88em;
 
     function removeBodyClassAndUnwatch() {
         if (document.body) document.body.classList.remove('ab-revamp-fullwidth');
+        try { releaseDashboardShell(); } catch (_) {}
         if (bgSavedBody !== null && document.body) {
             document.body.style.background = bgSavedBody; bgSavedBody = null;
         }

--- a/Jellyfin.Plugin.AchievementBadges/Pages/index.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/index.html
@@ -61,6 +61,8 @@ align-items:center;
 
 .abShowcaseWrap{
 margin-top:1.1em;
+flex-basis:100%;
+width:100%;
 }
 
 .abSectionEyebrow{
@@ -74,7 +76,7 @@ margin-bottom:0.7em;
 
 .abShowcase{
 display:grid;
-grid-template-columns:repeat(auto-fill,minmax(190px,1fr));
+grid-template-columns:repeat(auto-fill,minmax(300px,1fr));
 gap:0.8em;
 }
 
@@ -1578,10 +1580,6 @@ font-size:0.88em;
                             </div>
                         </div>
 
-                        <div id="abShowcaseWrap" class="abShowcaseWrap">
-                            <div class="abSectionEyebrow" data-i18n="achievements.showcase">Showcase</div>
-                            <div id="abShowcaseRow" class="abShowcase"></div>
-                        </div>
                     </div>
 
                     <div class="abHeroActions">
@@ -1596,6 +1594,11 @@ font-size:0.88em;
                         <button is="emby-button" type="button" class="raised" id="abSimulateBtn" data-i18n="admin.btn_simulate_playback">
                             Simulate playback
                         </button>
+                    </div>
+
+                    <div id="abShowcaseWrap" class="abShowcaseWrap">
+                        <div class="abSectionEyebrow" data-i18n="achievements.showcase">Showcase</div>
+                        <div id="abShowcaseRow" class="abShowcase"></div>
                     </div>
                 </div>
 
@@ -2824,6 +2827,10 @@ font-size:0.88em;
         return fetchJson('Plugins/AchievementBadges/users/' + userId + '/summary').then(function (summary) {
             setSummary(summary);
             profileSubtitle.textContent = tr('achievements.completion', 'Completion') + ': ' + ((summary && summary.Percentage != null) ? summary.Percentage : 0) + '%';
+            // The translation applier rewrites every [data-i18n] element when
+            // the dictionary lands or the language changes; if that happens
+            // after this write, the subtitle goes back to "Loading...".
+            profileSubtitle.removeAttribute('data-i18n');
         });
     }
 
@@ -3027,6 +3034,7 @@ font-size:0.88em;
         // the failure.
         var summaryPromise = loadSummary(userId).catch(function (err) {
             profileSubtitle.textContent = tr('admin.msg.profile_failed', 'Could not load profile.');
+            profileSubtitle.removeAttribute('data-i18n');
             setSummary({ Unlocked: 0, Total: 0, Percentage: 0, EquippedCount: 0 });
             console.warn('[AchievementBadges] summary load failed', err);
         });
@@ -3064,6 +3072,7 @@ font-size:0.88em;
             leaderboardBox.innerHTML = tr('admin.msg.lb_failed', 'Failed to load leaderboard.');
             serverStatsBox.innerHTML = tr('admin.msg.server_stats_failed', 'Failed to load server stats.');
             profileSubtitle.textContent = tr('admin.msg.profile_failed', 'Could not load profile.');
+            profileSubtitle.removeAttribute('data-i18n');
             setSummary({ Unlocked: 0, Total: 0, Percentage: 0, EquippedCount: 0 });
             setStatus('');
             setError(tr('admin.msg.badges_load_failed', 'Failed to load badges.') + ' ' + (error && error.message ? error.message : String(error)));

--- a/Jellyfin.Plugin.AchievementBadges/Pages/navinject.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/navinject.js
@@ -1,6 +1,6 @@
 (function () {
     var ENTRY_ID = "achievement-badges-nav-entry";
-    var TARGET_URL = "/web/index.html#!/configurationpage?name=achievementbadges";
+    var TARGET_URL = "/web/index.html#/configurationpage?name=achievementbadges";
 
     function createNavEntry() {
         if (document.getElementById(ENTRY_ID)) return;

--- a/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-blades.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-blades.html
@@ -110,7 +110,7 @@
 </style>
 </head>
 <body>
-  <a class="ab-back-btn" href="/web/index.html#!/achievements" aria-label="Back to Jellyfin"
+  <a class="ab-back-btn" href="/web/index.html#/achievements" aria-label="Back to Jellyfin"
      onclick="try{if(document.referrer&&window.history.length>1){window.history.back();return false;}}catch(e){}return true;">
     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>
   </a>

--- a/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-metro.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/profile-card-metro.html
@@ -91,7 +91,7 @@
 </style>
 </head>
 <body>
-  <a class="ab-back-btn" href="/web/index.html#!/achievements" aria-label="Back to Jellyfin"
+  <a class="ab-back-btn" href="/web/index.html#/achievements" aria-label="Back to Jellyfin"
      onclick="try{if(document.referrer&&window.history.length>1){window.history.back();return false;}}catch(e){}return true;">
     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>
   </a>

--- a/Jellyfin.Plugin.AchievementBadges/Pages/profile-card.html
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/profile-card.html
@@ -122,7 +122,7 @@
 </style>
 </head>
 <body>
-  <a class="ab-back-btn" href="/web/index.html#!/achievements" aria-label="Back to Jellyfin"
+  <a class="ab-back-btn" href="/web/index.html#/achievements" aria-label="Back to Jellyfin"
      onclick="try{if(document.referrer&&window.history.length>1){window.history.back();return false;}}catch(e){}return true;">
     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>
   </a>

--- a/Jellyfin.Plugin.AchievementBadges/Pages/profileinject.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/profileinject.js
@@ -77,10 +77,10 @@
         wrapper.innerHTML =
             '<div style="display:flex;align-items:center;justify-content:space-between;gap:1em;flex-wrap:wrap;margin-bottom:0.8em;">' +
                 '<div style="font-size:1.05em;font-weight:700;">Achievements Showcase</div>' +
-                '<a href="/web/index.html#!/configurationpage?name=achievementbadges" style="color:#7dd3fc;text-decoration:none;font-weight:600;">Open Achievements</a>' +
+                '<a href="/web/index.html#/configurationpage?name=achievementbadges" style="color:#7dd3fc;text-decoration:none;font-weight:600;">Open Achievements</a>' +
             '</div>' +
             '<iframe ' +
-                'src="/web/index.html#!/configurationpage?name=achievementbadgesshowcase&userId=' + encodeURIComponent(userId) + '" ' +
+                'src="/web/index.html#/configurationpage?name=achievementbadgesshowcase&userId=' + encodeURIComponent(userId) + '" ' +
                 'style="width:100%;min-height:90px;border:0;background:transparent;" ' +
                 'loading="lazy">' +
             '</iframe>';

--- a/Jellyfin.Plugin.AchievementBadges/Pages/shell.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/shell.js
@@ -1,5 +1,5 @@
 (function () {
-    const ROUTE = "#!/achievements";
+    const ROUTE = "#/achievements";
     const ROOT_ID = "achievementBadgesShellRoot";
     const PROFILE_ROOT_ID = "achievementBadgesProfileShowcase";
     const HOME_WIDGET_ID = "achievementBadgesHomeWidget";
@@ -800,7 +800,7 @@
 
         const item = document.createElement("a");
         item.id = SIDEBAR_ID;
-        item.href = "/web/index.html#!/achievements";
+        item.href = "/web/index.html#/achievements";
         item.className = "navMenuOption";
         item.style.display = "flex";
         item.style.alignItems = "center";
@@ -815,7 +815,7 @@
 
         item.addEventListener("click", function (event) {
             event.preventDefault();
-            window.location.hash = "#!/achievements";
+            window.location.hash = "#/achievements";
         });
     }
 
@@ -831,7 +831,7 @@
             <div class="ab-wrap">
                 <div class="ab-topbar">
                     <h2 style="margin:0;">Achievements</h2>
-                    <a class="ab-back" href="/web/index.html#!/home">
+                    <a class="ab-back" href="/web/index.html#/home">
                         <span>←</span>
                         <span>Back Home</span>
                     </a>
@@ -1687,7 +1687,7 @@
         wrapper.innerHTML =
             '<div style="display:flex;align-items:center;justify-content:space-between;gap:1em;flex-wrap:wrap;margin-bottom:0.8em;">' +
                 '<div style="font-size:1.05em;font-weight:700;">🏅 Achievements Showcase</div>' +
-                '<a href="/web/index.html#!/achievements" style="color:#7dd3fc;text-decoration:none;font-weight:600;">Open Achievements</a>' +
+                '<a href="/web/index.html#/achievements" style="color:#7dd3fc;text-decoration:none;font-weight:600;">Open Achievements</a>' +
             '</div>' +
             '<div id="achievementBadgesProfileItems" class="ab-profile-grid"></div>';
 
@@ -1768,7 +1768,7 @@
             <div class="ab-home-card">
                 <div class="ab-home-top">
                     <div style="font-size:1.05em;font-weight:700;">🏅 Achievements</div>
-                    <a href="/web/index.html#!/achievements" class="ab-btn">Open Achievements</a>
+                    <a href="/web/index.html#/achievements" class="ab-btn">Open Achievements</a>
                 </div>
 
                 <div class="ab-home-grid">
@@ -1849,8 +1849,8 @@
         const hash = window.location.hash || "";
         const isHomeLike =
             hash === "" ||
-            hash === "#!/home" ||
-            hash.startsWith("#!/home?");
+            hash === "#/home" ||
+            hash.startsWith("#/home?");
 
         if (!isHomeLike) {
             const existing = document.getElementById(HOME_WIDGET_ID);

--- a/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
@@ -4,6 +4,7 @@
     var SIDEBAR_ID='ab-sidebar-entry';
     var SHOWCASE_ID='ab-sidebar-showcase';
     var HEADER_ID='ab-header-badges';
+    var USER_MENU_ID='ab-user-menu-entry';
 
     /* v1.8.54: propagate the user's Classic/Revamp preference globally so the
        Friends drawer (mounted on body, on every Jellyfin page) follows the
@@ -143,6 +144,11 @@
         var hdr = document.getElementById(HEADER_ID);
         if (hdr){
             hdr.title = tr('sidebar.equipped_badges', 'Equipped Badges');
+        }
+        var um = document.getElementById(USER_MENU_ID);
+        if (um){
+            var umText = um.querySelector('.MuiListItemText-root .MuiTypography-root') || um.querySelector('.MuiListItemText-root');
+            if (umText) umText.textContent = tr('sidebar.achievements', 'Achievements');
         }
     }
 
@@ -325,6 +331,13 @@
             if (_showcaseEnabled === false) return; // admin or user disabled
             if(document.getElementById(HEADER_ID)){ return; }
             var headerRight=document.querySelector('.headerRight')||document.querySelector('.skinHeader .headerButton:last-child');
+            if(!headerRight){
+                // [Jellyfin 12] The modern layout keeps .skinHeader in the DOM
+                // but hidden and empty. Its toolbar is MUI: sit right before
+                // the box that holds the avatar button.
+                var avatarBtn=document.querySelector('button[aria-controls="app-user-menu"]');
+                if(avatarBtn && avatarBtn.parentElement && avatarBtn.parentElement.parentElement){ headerRight=avatarBtn.parentElement; }
+            }
             if(!headerRight){ return; }
             console.log('[AchievementBadges] injectHeader: found header, adding badges container');
             var container=document.createElement('div');container.id=HEADER_ID;
@@ -336,6 +349,61 @@
             if(parent)parent.insertBefore(container,headerRight);
             refreshShowcases();
         } catch(e) { console.error('[AchievementBadges] injectHeader error:', e); }
+    }
+
+    // [Jellyfin 12] The modern layout (the default since 12.0) keeps
+    // .mainDrawer and .skinHeader in the DOM only so legacy scripts do not
+    // throw; both are hidden, so injectSidebar() and injectHeader() above
+    // land where nobody looks. The one navigation a regular user still has
+    // is the avatar menu: an MUI Menu with id "app-user-menu" that stays
+    // mounted while closed (keepMounted). Clone the Profile item so the
+    // entry inherits the MUI classes and behaves like its neighbours, and
+    // put it right below Profile. The legacy layouts (desktop-legacy,
+    // mobile-legacy, tv) still use the old drawer, so the injection above
+    // stays for them.
+    function injectUserMenu(){
+        try {
+            var menu=document.getElementById('app-user-menu');
+            if(!menu){ return; }
+            var list=menu.querySelector('ul[role="menu"]')||menu.querySelector('ul.MuiList-root');
+            if(!list){ return; }
+            var existing=document.getElementById(USER_MENU_ID);
+            if(existing && existing.parentNode===list){ return; }
+            if(existing && existing.parentNode){ existing.parentNode.removeChild(existing); }
+            var profile=list.querySelector('a[href*="/userprofile"]');
+            var template=profile||list.querySelector('a.MuiMenuItem-root')||list.querySelector('li.MuiMenuItem-root');
+            if(!template){ return; }
+            var item=template.cloneNode(true);
+            item.id=USER_MENU_ID;
+            item.setAttribute('href','#/achievements');
+            item.removeAttribute('aria-current');
+            item.classList.remove('Mui-selected','Mui-focusVisible');
+            var icon=item.querySelector('.MuiListItemIcon-root');
+            if(icon){
+                icon.innerHTML='<span class="material-icons" aria-hidden="true" style="font-family:Material Icons;font-size:24px;line-height:1;">emoji_events</span>';
+            }
+            var text=item.querySelector('.MuiListItemText-root .MuiTypography-root')||item.querySelector('.MuiListItemText-root');
+            if(text){ text.textContent=tr('sidebar.achievements','Achievements'); }
+            item.addEventListener('click',function(e){
+                e.preventDefault(); e.stopPropagation();
+                closeUserMenu();
+                window.location.hash='/achievements';
+            });
+            if(profile && profile.nextSibling){ list.insertBefore(item, profile.nextSibling); }
+            else { list.appendChild(item); }
+            console.log('[AchievementBadges] injectUserMenu: entry added below Profile');
+        } catch(e) { console.error('[AchievementBadges] injectUserMenu error:', e); }
+    }
+
+    // The clone carries none of React's handlers, so the menu would stay
+    // open after navigating. The popover closes when its backdrop is
+    // clicked; Escape is the fallback.
+    function closeUserMenu(){
+        try {
+            var backdrop=document.querySelector('#app-user-menu .MuiBackdrop-root');
+            if(backdrop){ backdrop.click(); return; }
+            document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape',bubbles:true}));
+        } catch(e) {}
     }
 
     function refreshShowcases(){
@@ -376,6 +444,7 @@
             if (!enabled) removeShowcaseDom();
             injectSidebar();
             injectHeader();
+            injectUserMenu();
         });
         // Idempotent — mounts the friends button/drawer exactly once, but
         // is cheap to call repeatedly so the retry loop covers the case

--- a/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/sidebar.js
@@ -93,10 +93,16 @@
         if(api._serverInfo&&api._serverInfo.UserId)return api._serverInfo.UserId;}catch(e){}return '';
     }
     function buildUrl(p){var api=getApi();var c=p.replace(/^\/+/,'');return(api&&typeof api.getUrl==='function')?api.getUrl(c):'/'+c;}
+    // [Jellyfin 12] Legacy authorization (X-Emby-Token, X-MediaBrowser-Token,
+    // api_key in the query) is switched off by a 12.0 migration, so every
+    // authenticated call answered 401. Send the current form; the legacy
+    // header stays because 10.11 accepts either.
+    function setTokenHeaders(h,t){ h['Authorization']='MediaBrowser Token="'+t+'"'; h['X-Emby-Token']=t; return h; }
     function authHeaders(){
         var h={'Content-Type':'application/json'};var api=getApi();if(!api)return h;
-        try{if(typeof api.accessToken==='function'){var t=api.accessToken();if(t)h['X-Emby-Token']=t;}
-        else if(api._serverInfo&&api._serverInfo.AccessToken)h['X-Emby-Token']=api._serverInfo.AccessToken;}catch(e){}return h;
+        try{var t=null;if(typeof api.accessToken==='function'){t=api.accessToken();}
+        if(!t&&api._serverInfo&&api._serverInfo.AccessToken){t=api._serverInfo.AccessToken;}
+        if(t){setTokenHeaders(h,t);}}catch(e){}return h;
     }
     function fetchEquipped(){
         var uid=getUserId();if(!uid)return Promise.resolve([]);

--- a/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
@@ -1177,7 +1177,7 @@
                        toggle. Persists via the same `ab-style-pref` localStorage
                        key so the user's choice is shared across both surfaces. */
                     '<button type="button" id="abSaStyleToggleBtn" class="abSaStyleToggleBtn" aria-pressed="false" title="Toggle Revamp / Classic UI" data-i18n="ui.toggle.classic">UI: Classic</button>' +
-                    '<a class="ab-back" href="/web/index.html#!/home">\u2190 <span data-i18n="achievements.back_home">Back Home</span></a>' +
+                    '<a class="ab-back" href="/web/index.html#/home">\u2190 <span data-i18n="achievements.back_home">Back Home</span></a>' +
                 '</div>' +
                 '<div class="ab-hero">' +
                     /* v1.8.52: hero arc donut on the right side. Hidden in Classic

--- a/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
@@ -4787,6 +4787,8 @@
         if (root.parentNode !== target) target.appendChild(root);
         activeHost = host || null;
         root.style.display = 'block';
+        applyDocumentTitle();
+        watchDocumentTitle();
 
         /* v1.8.47: apply the persisted Classic/Revamp preference + wire toggle. */
         applyStylePref(getStylePref());
@@ -4914,6 +4916,30 @@
         setTimeout(function () { if (toast.parentNode) dismiss(); }, 30000);
     }
 
+    // [Jellyfin 12] The SPA renders its "Page not found" route underneath
+    // this overlay and names the tab after it. While the route is ours the
+    // tab is named after the page the user actually sees; the SPA sets
+    // its own title again on the next route. The observer catches the
+    // SPA writing its title after the mount.
+    var TITLE_KEY = 'achievements.title';
+    var _titleObserver = null;
+    function applyDocumentTitle() {
+        try {
+            if (!isAchievementsRoute()) return;
+            var wanted = tr(TITLE_KEY, 'Achievements');
+            if (document.title !== wanted) document.title = wanted;
+        } catch (e) {}
+    }
+    function watchDocumentTitle() {
+        try {
+            if (_titleObserver) return;
+            var titleEl = document.querySelector('title');
+            if (!titleEl) return;
+            _titleObserver = new MutationObserver(function () { applyDocumentTitle(); });
+            _titleObserver.observe(titleEl, { childList: true, characterData: true, subtree: true });
+        } catch (e) {}
+    }
+
     function unmountRoute() {
         var r = document.getElementById(ROOT_ID);
         if (r) r.style.display = 'none';
@@ -4973,6 +4999,7 @@
             var r = document.getElementById(ROOT_ID);
             if (isAchievementsRoute()) {
                 if (!r || r.style.display === 'none' || r.parentNode !== document.body) onRouteChange();
+                applyDocumentTitle();
             } else {
                 var host = findIntegrationHost();
                 var shouldMount = host && integrationEnabled(host, publicConfigGlobal || {}, navigationPreferencesGlobal || {});

--- a/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/standalone.js
@@ -131,17 +131,25 @@
         return '/' + clean;
     }
 
+    // [Jellyfin 12] Legacy authorization (X-Emby-Token, X-MediaBrowser-Token,
+    // api_key in the query) is switched off by a 12.0 migration, so every
+    // authenticated call answered 401. Send the current form; the legacy
+    // header stays because 10.11 accepts either.
+    function setTokenHeaders(h, t) {
+        h['Authorization'] = 'MediaBrowser Token="' + t + '"';
+        h['X-Emby-Token'] = t;
+        return h;
+    }
+
     function getAuthHeadersImmediate() {
         var api = getApiClient();
         var h = { 'Content-Type': 'application/json' };
         if (!api) return h;
         try {
-            if (typeof api.accessToken === 'function') {
-                var t = api.accessToken();
-                if (t) h['X-Emby-Token'] = t;
-            } else if (api._serverInfo && api._serverInfo.AccessToken) {
-                h['X-Emby-Token'] = api._serverInfo.AccessToken;
-            }
+            var t = null;
+            if (typeof api.accessToken === 'function') t = api.accessToken();
+            if (!t && api._serverInfo && api._serverInfo.AccessToken) t = api._serverInfo.AccessToken;
+            if (t) setTokenHeaders(h, t);
         } catch (e) {}
         return h;
     }

--- a/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
+++ b/Jellyfin.Plugin.AchievementBadges/Pages/styles-revamp.css
@@ -5013,3 +5013,14 @@ body[data-ab-style="revamp"] #abFriendsBtn:focus-visible {
 #achievementBadgesStandaloneRoot[class*="border-"] .ab-hero::before {
     z-index: 1;
 }
+
+/* [Jellyfin 12] Inside the MUI dashboard the page still owns the viewport,
+   minus the docked drawer on the left and the app bar on top, both of
+   which sit on fixed layers above it. The bootstrap script measures the
+   two and sets the variables; the fallbacks are MUI's defaults. Specificity
+   0,3,1 beats the full viewport rule above (0,2,1). */
+body.ab-revamp-fullwidth.ab-dash-shell #AchievementBadgesPage {
+    inset: var(--ab-dash-top, 48px) 0 0 var(--ab-dash-left, 240px) !important;
+    width: auto !important;
+    height: auto !important;
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ```
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Jellyfin-10.11%2B-0b0b0b?style=for-the-badge&labelColor=000000&color=2b2b2b" />
+  <img src="https://img.shields.io/badge/Jellyfin-10.11%20and%2012-0b0b0b?style=for-the-badge&labelColor=000000&color=2b2b2b" />
   <img src="https://img.shields.io/badge/Type-Plugin-E50914?style=for-the-badge&labelColor=000000&color=E50914" />
   <img src="https://img.shields.io/badge/System-Achievements-0b0b0b?style=for-the-badge&labelColor=000000&color=2b2b2b" />
   <a href="https://github.com/ZL154/AchievementBadges_for_Jellyfin/releases/latest"><img src="https://img.shields.io/github/v/release/ZL154/AchievementBadges_for_Jellyfin?style=for-the-badge&labelColor=000000&color=2b2b2b&label=Release" /></a>
@@ -298,6 +298,7 @@ Xbox-Guide-style chat built into the Friends drawer. No external service, no Web
 ### 🏠 UI integration
 
 - **Sidebar entry** auto-injected into the Jellyfin nav menu (works on web, iOS, and Android after restart)
+- **Jellyfin 12**: the modern layout has no navigation drawer, so the entry sits in the avatar menu, right below Profile; the legacy layouts (desktop-legacy, mobile-legacy, TV) keep the drawer entry. The same plugin build runs on 10.11 and 12.
 - **Equipped badge showcase** in header + profile (configurable slot count, 1-10)
 - **Xbox-style unlock toasts** with per-rarity colors (6 tiers), Xbox logo → trophy swap, shimmer sweep, and confetti on rare+ unlocks
 - **Achievement sound** — Xbox 360 chime for common/uncommon, rare Xbox One chime for rare/epic/legendary/mythic
@@ -306,7 +307,7 @@ Xbox-Guide-style chat built into the Friends drawer. No external service, no Web
 - **Per-device toast delivery** — choose all signed-in devices (default) or only the Jellyfin device that earned the achievement
 - **Toasts during playback** — unlocks fire within ~1s of earning via playback event hooks + DOM fallback
 - **Admin toast preview** — test buttons for each rarity tier
-- **Standalone achievements page** at `#!/achievements` with the new **Loadout tab (v2.0)** for managing power-ups, shop, and cosmetics
+- **Standalone achievements page** at `#/achievements` with the new **Loadout tab (v2.0)** for managing power-ups, shop, and cosmetics
 - **Optional page hosts** — reuse the same page inside Custom Tabs or register it with Plugin Pages; both are admin opt-in and the stock page always remains available
 - **Modular per-user navigation** — independently show or hide the Custom Tabs entry, Plugin Pages entry, and header trophy without affecting achievement tracking or each other
 - **Shareable profile card (three skins, v2.3.0)** — server-rendered HTML at `/Plugins/AchievementBadges/users/{id}/profile-card`, in **Console** (default), **Metro**, or **Aurora Spine**, each drawn with the owner's rank colour as the accent. Users pick their skin in preferences; `?style=` overrides per link, and a request with no style falls back to the owner's choice

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -31,6 +31,16 @@ Requested by **@TsunamicFlame** in #115.
 - **Same abuse guards as everything else** (daily credit cap, suspicious-rate flag), without the completion gate and the six-hour per-item dedupe, which do not fit a session: the same game twice in an evening is two sessions.
 - **Not included, on purpose**: RetroAchievements sync. Nothing played in JellyEmu's browser emulator can unlock one, so it would only reward play that happens elsewhere.
 
+## Jellyfin 12
+
+Jellyfin 12.0 ships a new default layout and switches legacy authorization off. The same build runs on 10.11 and 12; nothing to configure.
+
+- **The Achievements entry moved to the avatar menu.** The modern layout keeps the old drawer and header in the DOM but hidden, so the sidebar entry and the equipped badge strip were injected where nobody could see them. On 12 the entry sits right below Profile in the avatar menu and the strip sits before the avatar in the toolbar. The legacy layouts (desktop-legacy, mobile-legacy, TV) keep the drawer entry.
+- **Every authenticated call answered 401.** The 12.0 migration `DisableLegacyAuthorization` refuses `X-Emby-Token`, `X-MediaBrowser-Token` and `api_key` in the query; the plugin sent only the first. All calls now carry `Authorization: MediaBrowser Token=...` next to it, which both versions accept.
+- **The Revamp admin page fits the dashboard.** It takes the viewport with `position: fixed`, and the dashboard's docked drawer and app bar sit on layers above it, hiding its left 240px and top 48px. The page now measures both and insets itself; Classic is unchanged.
+- **The tab is named Achievements** while the achievements page is open, instead of the "Page not found" the SPA route underneath used to set.
+- **Links use `#/` routes.** jellyfin-web 12 still redirects `#!/` with a deprecation warning; every link the plugin writes now uses the current format.
+
 ## Changed
 
 - The `library-completion/recompute` endpoint now also recomputes targeted progress and returns it, so a broken or unwanted scan does not leave targeted badges unreachable.


### PR DESCRIPTION
## Summary

Jellyfin 12.0 went GA on 2026-09-08 and breaks the plugin's web side in four places. I hit all four on my own server after upgrading, reproduced each on a throwaway 12.0.0 container with the plugin built from `main`, and fixed them one commit at a time, checking every fix live in the browser. The same build still runs on 10.11; nothing here depends on #117.

The worst one first: on 12 every authenticated call answered 401, so the badge grid, preferences, friends, toasts and the admin catalog were all dead ("Failed to load badges. Request failed: 401").

## What I changed

1. **The Achievements entry moved to the avatar menu** (d296d0c). jellyfin-web 12's default "modern" layout keeps `.mainDrawer` and `.skinHeader` in the DOM only so legacy scripts do not throw, both hidden (`src/components/AppHeader.tsx`), and its drawer (`MainDrawerContent.tsx`) never lists plugin pages, so `EnableInMainMenu` is ignored. `sidebar.js` injected the entry and the equipped badge strip into exactly those hidden elements. The avatar menu (`AppUserMenu.tsx`) is an MUI Menu with `id="app-user-menu"` and `keepMounted`, so its DOM exists while closed: the entry is a clone of the Profile item placed right below it, pointing at `#/achievements` and closing the menu through the popover backdrop, since the clone carries no React handler. The badge strip falls back to the MUI toolbar, before the avatar button. The legacy layouts (desktop-legacy, mobile-legacy, tv) still use the old drawer, so that injection stays.
2. **Authorization header** (c8461be). 12.0 runs the migration `20260531160000_DisableLegacyAuthorization`, which sets `EnableLegacyAuthorization = false`. Measured on 12.0.0 with one token against `users/{id}/preferences`:

   | Sent | 12.0 |
   |---|---|
   | `X-Emby-Token` | 401 |
   | `X-MediaBrowser-Token` | 401 |
   | `X-Emby-Authorization: MediaBrowser Token=...` | 401 |
   | `api_key` in the query | 401 |
   | `Authorization: MediaBrowser Token=...` | 200 |
   | `Authorization` and `X-Emby-Token` together | 200 |

   `AuthorizationContext` is byte for byte the same as 10.11.11; only the setting changed. The five assets that build headers (`sidebar.js`, `standalone.js`, `enhance.js`, `Pages/index.html`, `configPage.html`) now send `Authorization: MediaBrowser Token=...` next to the legacy header. A test reads each asset and refuses a legacy header that travels alone.
3. **The Revamp admin page fits the dashboard, and the tab has a name** (6fb48c1). Revamp takes the viewport with `position: fixed`. The MUI dashboard keeps a docked 240px drawer and a fixed app bar on layers above it, so the page's left 240px and top 48px were hidden (on my server the hero title was cut in half behind the drawer). The bootstrap now detects the shell by `.dashboard-appBar`, measures the docked drawer and the bar, and hands the values to the stylesheet, which insets the page by them; a `ResizeObserver` keeps the measurement right when the drawer switches between docked and overlay at MUI's md breakpoint. Classic releases everything. Separately, the achievements overlay sits on top of the SPA's not found route, which named the browser tab "Page not found"; the tab is now named Achievements while the achievements route is showing.
4. **`#/` routes** (417750e). jellyfin-web 12 still redirects `#!/` with a console warning that the format will stop working. Thirteen links in eight assets used it, including the achievements page's Back Home, the three shareable card back buttons and the classic config page redirect. A test reads eleven assets and refuses any `#!/`; `sidebar.js` keeps both spellings in its login route checks on purpose.
5. **Docs**: README (compatibility badge, UI integration section) and the v2.4.0 release note.
6. **Admin profile card** (eabbf0a). Seen on my server right after the upgrade: the profile subtitle flipped back to "Loading..." after the summary had written "Completion: 42.7%", because the translation applier rewrites every `[data-i18n]` element when the dictionary lands or the language changes; the subtitle now drops that attribute once it carries dynamic text, on success and on both failure paths. And the showcase sat in the hero's left column next to three wide buttons, so a 1400px card showed two columns of badges; it is now the hero's own full width row with 300px minimum columns (four across on a wide screen). Revamp builds its own hero and is not affected.

## Verification

| Check | Result |
|---|---|
| `dotnet test` | 280 passed, 0 failed (22 new cases in `Jellyfin12ShellTests`) |
| `dotnet build -c Release` | 0 warnings, 0 errors |
| `node --check` | the three injected scripts and the embedded scripts of both pages |
| 12.0.0 in Docker, plugin built from this branch, Chromium | avatar menu shows Profile, Achievements, Settings, Dashboard, Metadata Manager, Quick Connect, Sign Out; the entry closes the menu and lands on `#/achievements` |
| Same server, before and after the header fix | every `users/{id}/...` call 401, then 200; admin catalog with 256 items, achievements page with 38 badges and the profile card loaded |
| Same server, admin page | Revamp sits at x=240, y=48 up to the viewport edges next to the drawer; Classic back in normal flow with class and variables cleared |
| Same server, `#/achievements` | tab named Achievements immediately and 2 s later |
| My own server: Jellyfin 12.0.0 in Docker on Umbrel, this build installed as 2.3.1.1 through my fork's plugin manifest, two restarts | avatar menu entry, achievements page with the profile loaded, admin page in Revamp and Classic, all correct after a full reload; the 401s are gone |

I did not test the legacy layouts on 12 or the TV apps; the drawer injection for them is untouched by this PR. The admin card fix is the fifth commit and is on my server now as 2.3.1.2; the docs commit (README and release note) is the last one.

## Not in this PR

- `shell.js`, `navinject.js` and `profileinject.js` are loaded by nothing (no reference in C# or in the other scripts); they are the previous generation of `standalone.js`, `enhance.js` and `sidebar.js`. I updated their links here because it was one line each, but they deserve a removal in their own PR if you agree.
- A separate 12 build (#117) stays as it is; this PR is the same net9.0 build for both versions, which is what 12.0.0 loads today.